### PR TITLE
Use raw kelly stake in snapshot expansion

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1003,23 +1003,7 @@ def expand_snapshot_rows_with_kelly(
 
                 raw_kelly = kelly_fraction(p, odds, fraction=fraction)
 
-                prev_prob = None
-                if prior_snapshot_row:
-                    prev_prob = prior_snapshot_row.get(
-                        "market_prob"
-                    ) or prior_snapshot_row.get("consensus_prob")
-                curr_prob = bet.get("market_prob") or bet.get("consensus_prob")
-                try:
-                    observed_move = float(curr_prob) - float(prev_prob)
-                except Exception:
-                    observed_move = 0.0
-
-                hours = bet.get("hours_to_game")
-                book_count = extract_book_count(bet)
-                strength = confirmation_strength(
-                    observed_move, hours, book_count=book_count
-                )
-                stake = round(raw_kelly * (strength**1.5), 4)
+                stake = round(raw_kelly, 4)
                 ev = calculate_ev_from_prob(p, odds)
 
                 if base_fields["side"] == "St. Louis Cardinals":
@@ -1052,7 +1036,6 @@ def expand_snapshot_rows_with_kelly(
                         "stake": stake,
                         "full_stake": stake,
                         "raw_kelly": raw_kelly,
-                        "adjusted_kelly": stake,
                         "_prior_snapshot": prior_snapshot_row,
                         "_raw_sportsbook": raw_books,
                         "consensus_books": raw_books,
@@ -2226,7 +2209,6 @@ def log_bets(
             "blend_weight_model": round(w_model, 2),
             "stake": stake,
             "raw_kelly": raw_kelly,
-            "adjusted_kelly": stake,
             "entry_type": "",
             "segment": segment,
             "segment_label": get_segment_label(matched_key, side_clean),
@@ -2615,7 +2597,6 @@ def log_derivative_bets(
                     "blend_weight_model": round(w_model, 2),
                     "stake": stake,  # Will be updated to delta after comparing `prev`
                     "raw_kelly": raw_kelly,
-                    "adjusted_kelly": stake,
                     "entry_type": "",  # Set below based on `prev`
                     "segment": segment,
                     "segment_label": get_segment_label(market_full, side_clean),

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1341,16 +1341,7 @@ def expand_snapshot_rows_with_kelly(
                 fraction = 0.125 if row.get("market_class") == "alternate" else 0.25
                 raw_kelly = kelly_fraction(p, odds_val, fraction=fraction)
 
-                prev_prob = row.get("prev_market_prob")
-                curr_prob = row.get("market_prob")
-                try:
-                    observed_move = float(curr_prob) - float(prev_prob)
-                except Exception:
-                    observed_move = 0.0
-
-                hours = row.get("hours_to_game")
-                strength = confirmation_strength(observed_move, hours)
-                adjusted_kelly = round(raw_kelly * (strength ** 1.5), 4)
+                stake = round(raw_kelly, 4)
             except Exception:
                 continue
 
@@ -1363,10 +1354,9 @@ def expand_snapshot_rows_with_kelly(
                     "book": book,
                     "market_odds": odds_val,
                     "ev_percent": round(ev, 2),
-                    "stake": adjusted_kelly,
-                    "full_stake": adjusted_kelly,
+                    "stake": stake,
+                    "full_stake": stake,
                     "raw_kelly": raw_kelly,
-                    "adjusted_kelly": adjusted_kelly,
                     "_raw_sportsbook": per_book,
                     "consensus_books": per_book,
                 }


### PR DESCRIPTION
## Summary
- simplify stake sizing logic in `expand_snapshot_rows_with_kelly`
- stop using confirmation strength multiplier and drop `adjusted_kelly` field

## Testing
- `pytest -q`
- `python -m py_compile cli/log_betting_evals.py core/snapshot_core.py`


------
https://chatgpt.com/codex/tasks/task_e_685aa89ceb58832c8b1f6a9b6ef1559a