### PR TITLE
Apply raw_kelly after market confirmation

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -138,6 +138,10 @@ def recheck_pending_bets(path: str = PENDING_BETS_PATH) -> None:
         row["consensus_prob"] = new_prob
         row["market_prob"] = new_prob
         row["hours_to_game"] = hours_to_game
+        if row.get("entry_type") == "first":
+            raw_kelly = float(row.get("raw_kelly", 0))
+            row["stake"] = round(raw_kelly, 4)
+            row["full_stake"] = row["stake"]
         ref = {key: {"consensus_prob": prev_prob}}
         evaluated = should_log_bet(
             row,


### PR DESCRIPTION
## Summary
- set stake to raw_kelly once the market movement threshold is met in `monitor_early_bets`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aac4ad308832cad9e341c73be2d50