### PR TITLE
Remove adjusted_kelly field

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -89,6 +89,7 @@ def recheck_pending_bets(path: str = PENDING_BETS_PATH) -> None:
 
     updated = {}
     for key, bet in pending.items():
+        bet.pop("adjusted_kelly", None)
         start_dt = _start_time_from_gid(bet["game_id"])
         if not start_dt:
             continue
@@ -135,6 +136,7 @@ def recheck_pending_bets(path: str = PENDING_BETS_PATH) -> None:
             updated[key] = bet
             continue
         row = bet.copy()
+        row.pop("adjusted_kelly", None)
         row["consensus_prob"] = new_prob
         row["market_prob"] = new_prob
         row["hours_to_game"] = hours_to_game
@@ -152,6 +154,7 @@ def recheck_pending_bets(path: str = PENDING_BETS_PATH) -> None:
             existing_csv_stakes=existing,
         )
         if evaluated:
+            evaluated.pop("adjusted_kelly", None)
             result = write_to_csv(
                 evaluated,
                 "logs/market_evals.csv",

--- a/core/pending_bets.py
+++ b/core/pending_bets.py
@@ -59,7 +59,11 @@ def queue_pending_bet(bet: dict, path: str = PENDING_BETS_PATH) -> None:
     """Append or update ``bet`` in ``pending_bets.json``."""
     pending = load_pending_bets(path)
     key = f"{bet['game_id']}:{bet['market']}:{bet['side']}"
-    bet_copy = {k: v for k, v in bet.items() if not k.startswith('_')}
+    bet_copy = {
+        k: v
+        for k, v in bet.items()
+        if not k.startswith("_") and k != "adjusted_kelly"
+    }
     bet_copy['queued_ts'] = datetime.now().isoformat()
     pending[key] = bet_copy
     save_pending_bets(pending, path)

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -910,7 +910,6 @@ def build_snapshot_rows(
                 "stake": stake,
                 "full_stake": stake,
                 "raw_kelly": raw_kelly,
-                "adjusted_kelly": stake,
                 "segment": segment,
                 "market_class": market_class,
                 "best_book": best_book,


### PR DESCRIPTION
## Summary
- scrub adjusted_kelly from expanded snapshot rows
- remove adjusted_kelly when queuing and rechecking pending bets

## Testing
- `python -m py_compile core/pending_bets.py cli/monitor_early_bets.py core/snapshot_core.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aafc2be00832caeffb63fcdf4c2d9