### PR TITLE
Fix stake calc logic

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -285,7 +285,14 @@ def should_log_bet(
     new_bet["side"] = side  # ensure consistent formatting
     # ``full_stake`` may be absent in legacy entries; fall back to ``stake``
     # or 0.0 to avoid KeyError.
-    stake = round_stake(float(new_bet.get("full_stake", new_bet.get("stake", 0.0))))
+    stake = round_stake(
+        float(
+            new_bet.get(
+                "raw_kelly",
+                new_bet.get("full_stake", new_bet.get("stake", 0.0)),
+            )
+        )
+    )
     ev = new_bet["ev_percent"]
 
     segment = normalize_segment(market)


### PR DESCRIPTION
## Summary
- use `raw_kelly` when determining stake size in `should_log_bet`
- keep delta calculation based on unscaled Kelly stake

## Testing
- `pytest -q`
- `python -m py_compile core/should_log_bet.py`


------
https://chatgpt.com/codex/tasks/task_e_685ab5232d4c832c9e77cf652ffd4d40