### PR TITLE
Drop adjusted_kelly from CSV rows

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1890,7 +1890,13 @@ def write_to_csv(
             row.pop("blend_weight_model", None)
 
             # Remove transient keys not meant for CSV output
-            for k in ["_movement", "_movement_str", "_prior_snapshot", "full_stake"]:
+            for k in [
+                "_movement",
+                "_movement_str",
+                "_prior_snapshot",
+                "full_stake",
+                "adjusted_kelly",
+            ]:
                 row.pop(k, None)
 
             # Attach logger configuration for audit trail


### PR DESCRIPTION
## Summary
- avoid writing `adjusted_kelly` to `market_evals.csv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab6debfec832c86888d67711272de