### PR TITLE
Refactor should_log_bet baseline logic

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -3151,7 +3151,6 @@ def process_theme_logged_bets(
                     existing_theme_stakes,
                     verbose=config.VERBOSE_MODE,
                     eval_tracker=MARKET_EVAL_TRACKER,
-                    reference_tracker=MARKET_EVAL_TRACKER_BEFORE_UPDATE,
                     existing_csv_stakes=existing,
                 )
 

--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -220,13 +220,11 @@ def recheck_pending_bets(
             raw_kelly = float(row.get("raw_kelly", 0))
             row["stake"] = round(raw_kelly, 4)
             row["full_stake"] = row["stake"]
-        ref = {key: {"consensus_prob": baseline}}
         evaluated = should_log_bet(
             row,
             theme_stakes,
             verbose=False,
             eval_tracker=eval_tracker,
-            reference_tracker=ref,
             existing_csv_stakes=existing,
         )
         if evaluated:


### PR DESCRIPTION
## Summary
- simplify should_log_bet: drop reference tracker and movement checks
- gate new bets based on provided consensus/required move
- update command line tools for new function signature

## Testing
- `python -m pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c081184a8832ca4d2a973ac4eff26