### PR TITLE
Fix deduplication for CLV snapshot

### DIFF
--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -350,6 +350,10 @@ def build_snapshot_rows(
                 "CLV%": f"{clv_pct:+.1f}%",
                 "Stake": f"{stake:.2f}u",
                 "Expected Profit": f"{expected_profit:.2f}u",
+                "game_id": gid,
+                "market": row.get("market", ""),
+                "side": row.get("side"),
+                "book": row.get("best_book", row.get("book", "")),
             }
         )
     if skipped and not verbose:


### PR DESCRIPTION
## Summary
- keep source betting fields when building CLV snapshot rows
- deduplicate snapshot rows using game/market/side/book keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c57a08c30832c9bc2f5b48ff7d502