### PR TITLE
Ensure snapshot rows retain raw stake data

### DIFF
--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -320,6 +320,13 @@ def build_snapshot_rows(
         except Exception:
             stake = 0.0
         expected_profit = round(stake * clv_pct / 100, 2)
+
+        # Store raw values back into the row for downstream filtering/deduping
+        row["stake"] = stake
+        row["game_id"] = gid
+        row["market"] = row.get("market")
+        row["side"] = row.get("side")
+        row["book"] = row.get("book") or row.get("best_book")
         parts = parse_game_id(gid)
         date = row.get("Date") or parts.get("date", "")
         matchup = row.get("Matchup") or f"{parts.get('away','')} @ {parts.get('home','')}"


### PR DESCRIPTION
## Summary
- keep raw values on CLV snapshot rows

## Testing
- `python -m py_compile core/dispatch_clv_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_685c6153a8e8832cb7cea0295ec7e95c