### PR TITLE
Remove internal columns from CLV snapshot

### DIFF
--- a/core/dispatch_clv_snapshot.py
+++ b/core/dispatch_clv_snapshot.py
@@ -588,6 +588,15 @@ def main() -> None:
             logger.warning("❌ No 'CLV%' column found — skipping sort.")
             df["CLV%"] = "–"
 
+    drop_cols = [
+        "game_id",
+        "market",
+        "side",
+        "book",  # lowercase raw fields
+        "label",  # optional, if already merged into Bet
+    ]
+    df = df.drop(columns=[col for col in drop_cols if col in df.columns])
+
     if args.output_discord and WEBHOOK_URL:
         send_snapshot(df, WEBHOOK_URL, counts)
     else:


### PR DESCRIPTION
## Summary
- drop internal columns from CLV snapshot before sending to Discord

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c73b027dc832ca73cb97635e68a65