### PR TITLE
Keep logged bets in pending list

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -239,7 +239,9 @@ def recheck_pending_bets(
             if result and not result.get("skip_reason") and result.get("side"):
                 record_successful_log(result, existing, theme_stakes)
                 save_theme_stakes(theme_stakes)
-                continue
+                bet.update(result)
+                bet["logged"] = True
+                bet["logged_ts"] = datetime.now().isoformat()
             else:
                 logger.warning(
                     "❌ Skipping tracker update: result was skipped or malformed → %s",

--- a/core/pending_bets.py
+++ b/core/pending_bets.py
@@ -64,6 +64,10 @@ def queue_pending_bet(bet: dict, path: str = PENDING_BETS_PATH) -> None:
         for k, v in bet.items()
         if not k.startswith("_") and k != "adjusted_kelly"
     }
-    bet_copy['queued_ts'] = datetime.now().isoformat()
+    existing = pending.get(key, {})
+    bet_copy["queued_ts"] = existing.get("queued_ts", datetime.now().isoformat())
+    bet_copy["logged"] = bool(existing.get("logged", False))
+    if "logged_ts" in existing:
+        bet_copy["logged_ts"] = existing["logged_ts"]
     pending[key] = bet_copy
     save_pending_bets(pending, path)

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -121,7 +121,10 @@ def _pending_rows_for_date(date_str: str, min_ev: float = 5.0) -> list:
         row = bet.copy()
         row["book"] = row.get("book", row.get("best_book"))
 
-        row["snapshot_stake"] = round(rk, 2)
+        if bet.get("logged") and "stake" in bet:
+            row["snapshot_stake"] = round(float(bet.get("stake", rk)), 2)
+        else:
+            row["snapshot_stake"] = round(rk, 2)
         row["is_prospective"] = True
 
         if "sim_prob" in row:


### PR DESCRIPTION
## Summary
- preserve logged bets in `pending_bets.json`
- mark logged bets with a timestamp when processed
- show actual stake for logged bets in snapshot feed

## Testing
- `pytest -q`
- `python -m py_compile core/pending_bets.py cli/monitor_early_bets.py core/unified_snapshot_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_685c995937f4832c8cd3b6ab21da845b