### PR TITLE
Remove stake_display from snapshot rows

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -155,7 +155,6 @@ def _pending_rows_for_date(date_str: str, min_ev: float = 5.0) -> list:
             row["fv_display"] = "-"
 
         row["odds_display"] = row.get("market_odds", "-")
-        row["stake_display"] = f"{round(row['snapshot_stake'], 2)}u"
         row["skip_reason"] = bet.get("skip_reason", None)
         row["logged"] = bet.get("logged", False)
 
@@ -206,7 +205,6 @@ def _pending_rows_for_date(date_str: str, min_ev: float = 5.0) -> list:
             row["fv_display"] = "-"
 
         row["odds_display"] = row.get("market_odds", "-")
-        row["stake_display"] = f"{round(row['snapshot_stake'], 2)}u"
 
         role = _assign_snapshot_role(row)
         row["snapshot_role"] = role


### PR DESCRIPTION
## Summary
- remove `stake_display` generation in snapshot helpers
- drop references when printing debug lines
- stop populating `stake_display` in unified snapshot generator

## Testing
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_685c9b8594d4832cb73e3db10ddce082