### PR TITLE
Apply dynamic threshold to top-ups

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1735,7 +1735,7 @@ def write_to_csv(
 
     threshold = market_prob_increase_threshold(hours_to_game, row.get("market", ""))
 
-    if row.get("entry_type") == "first":
+    if row.get("entry_type") in {"first", "top-up"}:
         if prior_prob is None or new_prob is None:
             print(
                 "⛔ No prior market probability — building baseline and skipping log."

--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -15,8 +15,8 @@ __all__ = [
 
 # Alignment-first betting strategy:
 # - Only place a first bet when market movement confirms the model edge.
-# - After a bet is placed, top-ups rely solely on model value without
-#   additional confirmation.
+# - Top-ups now also require market confirmation using the same
+#   dynamic movement threshold applied to first bets.
 
 # Toggle for optional debug logging
 VERBOSE = False

--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -369,7 +369,7 @@ def should_log_bet(
             f"⚠️ Theme stake exists ({theme_total}) but no CSV stake for {side}. Tracker may be stale."
         )
         delta_base = 0.0
-    if new_bet.get("entry_type") == "first" and new_bet.get("consensus_move", 0.0) < new_bet.get("required_move", 0.0):
+    if new_bet.get("entry_type") in {"first", "top-up"} and new_bet.get("consensus_move", 0.0) < new_bet.get("required_move", 0.0):
         return {"skip_reason": "not_confirmed", "stake": 0.0, **new_bet}
 
     tracker_key = f"{game_id}:{market}:{side}"


### PR DESCRIPTION
## Summary
- update strategy docs to note top-ups also need market confirmation
- require market confirmation in `should_log_bet` for top-ups
- enforce dynamic market movement threshold when logging top-up bets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ca354b650832c832ad7876739dc7d