### PR TITLE
Loosen confirmation threshold for certain markets

### DIFF
--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -79,6 +79,19 @@ def required_market_move(
 
     base_threshold = movement_unit * time_multiplier * book_multiplier
 
+    # Loosen confirmation for full-game totals and spreads
+    if market and (
+        (
+            market.startswith("totals")
+            or market.startswith("spreads")
+            or market.startswith("runline")
+        )
+        and "1st_" not in market
+        and "1st" not in market
+        and "team_totals" not in market
+    ):
+        base_threshold *= 0.75
+
     # Volatile segments like first inning or team totals require more movement
     if market and (
         "1st_3" in market or "1st_7" in market or "team_totals" in market


### PR DESCRIPTION
## Summary
- reduce the required market move for full-game totals, spreads, and runlines
- keep existing multiplier for volatile segments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cad9bd4a8832c9261494cc4265272