### PR TITLE
Fix nested odds snapshot handling

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -3204,6 +3204,9 @@ if __name__ == "__main__":
         if odds is None:
             logger.warning("❌ Failed to load odds file %s", args.odds_path)
             sys.exit(1)
+        # ✅ Extract "games" key if snapshot is nested (e.g. { "games": { <game_id>: {...} } })
+        if isinstance(odds, dict) and "games" in odds:
+            odds = odds["games"]
         odds_file = args.odds_path
     else:
         from pathlib import Path


### PR DESCRIPTION
## Summary
- handle nested `games` key in odds snapshot file

## Testing
- `pytest -q` *(fails: no tests, network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d5cb2b5d8832c90d09ccb324cf73b