### PR TITLE
Add snapshot pending-bet updater

### DIFF
--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""Generate pending_bets.json from latest snapshot file."""
+
+import os
+import json
+import glob
+
+from core.market_eval_tracker import build_tracker_key
+from core.utils import safe_load_json
+from cli.log_betting_evals import load_market_conf_tracker
+
+SNAPSHOT_DIR = os.path.join("backtest")
+PENDING_JSON = os.path.join("logs", "pending_bets.json")
+
+
+def load_latest_snapshot(directory: str = SNAPSHOT_DIR) -> tuple[list, str | None]:
+    """Return rows from the most recent ``snapshot_*.json`` in ``directory``."""
+    pattern = os.path.join(directory, "snapshot_*.json")
+    files = sorted(glob.glob(pattern))
+    if not files:
+        return [], None
+    latest = max(files, key=os.path.getmtime)
+    data = safe_load_json(latest)
+    if isinstance(data, list):
+        rows = data
+    elif isinstance(data, dict):
+        rows = list(data.values())
+    else:
+        rows = []
+    return rows, latest
+
+
+def filter_rows(rows: list) -> list:
+    """Return rows meeting the EV/Kelly/logged criteria."""
+    filtered = []
+    for row in rows:
+        try:
+            logged = bool(row.get("logged"))
+            ev = float(row.get("ev_percent", 0))
+            rk = float(row.get("raw_kelly", 0))
+        except Exception:
+            continue
+        if logged or ev < 5.0 or rk < 1.0:
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def build_pending(rows: list, tracker: dict) -> dict:
+    """Convert ``rows`` into pending bet entries keyed by tracker key."""
+    pending: dict = {}
+    for row in rows:
+        key = build_tracker_key(row.get("game_id"), row.get("market"), row.get("side"))
+        entry = {
+            "game_id": row.get("game_id"),
+            "market": row.get("market"),
+            "side": row.get("side"),
+            "ev_percent": row.get("ev_percent"),
+            "raw_kelly": row.get("raw_kelly"),
+            "market_odds": row.get("market_odds"),
+            "sim_prob": row.get("sim_prob"),
+            "market_prob": row.get("market_prob"),
+            "blended_fv": row.get("blended_fv"),
+            "book": row.get("book") or row.get("best_book"),
+            "date_simulated": row.get("date_simulated"),
+            "skip_reason": row.get("skip_reason"),
+            "logged": row.get("logged", False),
+        }
+        if key in tracker and isinstance(tracker[key], dict):
+            cp = tracker[key].get("consensus_prob")
+            if cp is not None:
+                entry["baseline_consensus_prob"] = cp
+        pending[key] = entry
+    return pending
+
+
+def save_pending_bets(pending: dict, path: str = PENDING_JSON) -> None:
+    """Atomically write ``pending`` to ``path``."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = f"{path}.tmp"
+    with open(tmp, "w") as f:
+        json.dump(pending, f, indent=2)
+    os.replace(tmp, path)
+
+
+def main() -> None:
+    rows, snap = load_latest_snapshot()
+    if snap is None or not rows:
+        print("❌ No snapshot data found")
+        return
+
+    tracker = load_market_conf_tracker()
+    filtered = filter_rows(rows)
+    pending = build_pending(filtered, tracker)
+    save_pending_bets(pending, PENDING_JSON)
+
+    print(f"✅ Saved {len(pending)} entries from {os.path.basename(snap)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `update_pending_from_snapshot.py` script to build pending bets from the latest snapshot

## Testing
- `python -m py_compile scripts/update_pending_from_snapshot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9910303c832cb7df1b452dfe9cc0