### PR TITLE
Update pending-bets rebuild after snapshot

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -438,6 +438,7 @@ if initial_odds:
                 break
             time.sleep(0.2)
 
+        run_subprocess([PYTHON, "-m", "scripts.update_pending_from_snapshot"])
         recheck_pending_bets()
 
 start_time = time.time()
@@ -509,6 +510,7 @@ while True:
                         break
                     time.sleep(0.2)
 
+                run_subprocess([PYTHON, "-m", "scripts.update_pending_from_snapshot"])
                 recheck_pending_bets()
 
         last_log_time = now


### PR DESCRIPTION
## Summary
- run `update_pending_from_snapshot.py` after each snapshot
- wait for snapshot to be fully written before rebuilding pending bets

## Testing
- `python -m compileall -q cli/auto_sim_and_log_loop.py`
- `pytest -q` *(fails: no tests, network block)*

------
https://chatgpt.com/codex/tasks/task_e_685d9c4a9150832ca9c540a2bb18e32c