### PR TITLE
Implement enrich_pending_row helper

### DIFF
--- a/core/market_normalizer.py
+++ b/core/market_normalizer.py
@@ -1,0 +1,21 @@
+from core.utils import (
+    normalize_market_key as _normalize_market_key_str,
+    classify_market_segment,
+    get_segment_label,
+    normalize_lookup_side,
+)
+
+
+def normalize_market_key(market: str) -> dict:
+    """Return metadata derived from a market key."""
+    market = market or ""
+    mkey = _normalize_market_key_str(market)
+    segment = classify_market_segment(mkey)
+    market_class = "alternate" if "alternate" in market else "main"
+    label = get_segment_label(mkey, "")
+    return {"segment": segment, "market_class": market_class, "label": label}
+
+
+def normalize_side(side: str) -> str:
+    """Normalize side label for lookup."""
+    return normalize_lookup_side(side)


### PR DESCRIPTION
## Summary
- add `core.market_normalizer` utility
- simplify pending row enrichment
- update `monitor_early_bets` to use the helper

## Testing
- `python -m compileall -q cli/monitor_early_bets.py core/market_normalizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e443663c4832c859c17652d1e2230