### PR TITLE
Use total stake for snapshot filters

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -3010,7 +3010,9 @@ def process_theme_logged_bets(
     failed_log_count = 0
     for best_row in best_market_segment.values():
         # Skip bets that failed evaluation or have too small a stake
-        if best_row.get("skip_reason") or best_row.get("stake", 0) < 1.0:
+        if best_row.get("skip_reason") or best_row.get(
+            "total_stake", best_row.get("stake", 0)
+        ) < 1.0:
             continue
 
         if config.VERBOSE_MODE:

--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -113,7 +113,7 @@ def main() -> None:
 
     filtered = []
     for r in rows:
-        stake_val = r.get("stake") or r.get("snapshot_stake") or 0
+        stake_val = r.get("total_stake", r.get("stake") or r.get("snapshot_stake") or 0)
         if stake_val < 1.0 and not r.get("is_prospective"):
             continue
         filtered.append(r)

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -156,7 +156,7 @@ def main() -> None:
 
     filtered = []
     for r in rows:
-        stake_val = r.get("stake") or r.get("snapshot_stake") or 0
+        stake_val = r.get("total_stake", r.get("stake") or r.get("snapshot_stake") or 0)
         if stake_val < 1.0 and not r.get("is_prospective"):
             continue
         filtered.append(r)

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -107,7 +107,7 @@ def main() -> None:
 
     filtered = []
     for r in rows:
-        stake_val = r.get("stake") or r.get("snapshot_stake") or 0
+        stake_val = r.get("total_stake", r.get("stake") or r.get("snapshot_stake") or 0)
         if stake_val < 1.0 and not r.get("is_prospective"):
             continue
         filtered.append(r)

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -124,7 +124,7 @@ def main() -> None:
 
     filtered = []
     for r in rows:
-        stake_val = r.get("stake") or r.get("snapshot_stake") or 0
+        stake_val = r.get("total_stake", r.get("stake") or r.get("snapshot_stake") or 0)
         if stake_val < 1.0 and not r.get("is_prospective"):
             continue
         filtered.append(r)


### PR DESCRIPTION
## Summary
- filter snapshot rows based on total stake rather than latest top-up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea23f08c4832cacbb01f8e0808e02