### PR TITLE
Fix stake display in snapshots

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1069,7 +1069,9 @@ def format_for_display(rows: list, include_movement: bool = False) -> pd.DataFra
 
         df["Stake"] = df.apply(_fmt_stake, axis=1)
     else:
-        df["Stake"] = df["stake"].map("{:.2f}u".format)
+        df["Stake"] = df.apply(
+            lambda row: f"{row.get('total_stake', row['stake']):.2f}u", axis=1
+        )
 
     if "snapshot_stake" in df.columns:
         def _apply_snapshot_stake(row):


### PR DESCRIPTION
## Summary
- display `total_stake` when available in snapshot tables

## Testing
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_685ea48d4dd8832c9b4051d2e699559c