### PR TITLE
Fix circular import between exposure modules

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -32,6 +32,13 @@ import os
 
 from core.theme_key_utils import make_theme_key, theme_key_equals
 from core.theme_exposure_tracker import build_theme_key
+from core.theme_utils import (
+    normalize_market_key,
+    parse_team_total_side,
+    get_theme,
+    get_theme_key,
+    normalize_segment,
+)
 
 
 from core.utils import (
@@ -52,95 +59,10 @@ def _log_verbose(msg: str, verbose: bool = True) -> None:
         print(msg)
 
 
-def normalize_market_key(market: str) -> str:
-    """Return a canonical key for a market name."""
-    base = market.replace("alternate_", "").lower()
-    if base.startswith("totals") or base.startswith("team_totals"):
-        return "total"
-    if base.startswith("spreads") or base.startswith("runline"):
-        return "spread"
-    if base in {"h2h", "moneyline"} or base.startswith("h2h") or base.startswith("moneyline"):
-        return "h2h"
-    return base
-
-
-def get_theme(bet: dict) -> str:
-    """Return the exposure theme for a bet."""
-    side = bet["side"].strip()
-    market = bet["market"].replace("alternate_", "")
-
-    # 🆕 Handle team total bets like "ATL Over 4.5" or "Los Angeles Over 5.0"
-    if "team_totals" in market:
-        _, direction = parse_team_total_side(side)
-        if direction:
-            return direction
-
-    if side.startswith("Over"):
-        return "Over"
-    if side.startswith("Under"):
-        return "Under"
-
-    if "h2h" in market or "spreads" in market or "runline" in market:
-        tokens = side.split()
-        if tokens:
-            first = tokens[0]
-            if first.upper() in TEAM_ABBR_TO_NAME:
-                return first.upper()
-            if first.title() in TEAM_NAME_TO_ABBR:
-                return TEAM_NAME_TO_ABBR[first.title()]
-        for name in TEAM_NAME_TO_ABBR:
-            if side.startswith(name):
-                return name
-    return "Other"
-
-
-def get_theme_key(market: str, theme: str) -> str:
-    """Return a theme key combining theme name with a normalized market."""
-    key = normalize_market_key(market)
-    if key in {"total", "spread", "h2h"}:
-        return f"{theme}_{key}"
-    return f"{theme}_other"
-
-
 def get_segment_group(market: str) -> str:
     base = market.replace("alternate_", "")
     seg = classify_market_segment(base)
     return "derivative" if seg != "full_game" else "full_game"
-
-
-def normalize_segment(market: str) -> str:
-    """Return a unified segment tag from a raw market name."""
-    m = market.lower()
-    if "1st_3" in m:
-        return "1st_3"
-    if "1st_5" in m:
-        return "1st_5"
-    if "1st_7" in m:
-        return "1st_7"
-    if "1st_1" in m or "1st_inning" in m:
-        return "1st"
-    return "full_game"
-
-
-def parse_team_total_side(side: str) -> tuple[str, str]:
-    """Return team abbreviation and direction from a team total label."""
-    tokens = side.split()
-    direction = "Over" if "Over" in tokens else "Under" if "Under" in tokens else ""
-
-    team_abbr = None
-    # common formats: 'ATL Over 4.5' or 'Over 4.5 ATL'
-    for token in tokens:
-        if token.upper() in TEAM_ABBR_TO_NAME:
-            team_abbr = token.upper()
-            break
-        if token.title() in TEAM_NAME_TO_ABBR:
-            team_abbr = TEAM_NAME_TO_ABBR[token.title()]
-            break
-
-    if not team_abbr:
-        team_abbr = tokens[0].upper()
-
-    return team_abbr, direction
 
 
 def get_bet_group_key(bet: dict) -> str:

--- a/core/theme_exposure_tracker.py
+++ b/core/theme_exposure_tracker.py
@@ -4,7 +4,7 @@ import ast
 from typing import Dict
 
 from .theme_key_utils import make_theme_key, parse_theme_key
-from core.should_log_bet import get_theme, get_theme_key, normalize_segment
+from core.theme_utils import get_theme, get_theme_key, normalize_segment
 
 from core.file_utils import with_locked_file
 

--- a/core/theme_utils.py
+++ b/core/theme_utils.py
@@ -1,0 +1,89 @@
+"""Utility helpers for exposure theme handling."""
+
+from core.utils import TEAM_ABBR_TO_NAME, TEAM_NAME_TO_ABBR
+
+
+def normalize_market_key(market: str) -> str:
+    """Return a canonical key for a market name."""
+    base = market.replace("alternate_", "").lower()
+    if base.startswith("totals") or base.startswith("team_totals"):
+        return "total"
+    if base.startswith("spreads") or base.startswith("runline"):
+        return "spread"
+    if base in {"h2h", "moneyline"} or base.startswith("h2h") or base.startswith("moneyline"):
+        return "h2h"
+    return base
+
+
+def parse_team_total_side(side: str) -> tuple[str, str]:
+    """Return team abbreviation and direction from a team total label."""
+    tokens = side.split()
+    direction = "Over" if "Over" in tokens else "Under" if "Under" in tokens else ""
+
+    team_abbr = None
+    # common formats: 'ATL Over 4.5' or 'Over 4.5 ATL'
+    for token in tokens:
+        if token.upper() in TEAM_ABBR_TO_NAME:
+            team_abbr = token.upper()
+            break
+        if token.title() in TEAM_NAME_TO_ABBR:
+            team_abbr = TEAM_NAME_TO_ABBR[token.title()]
+            break
+
+    if not team_abbr:
+        team_abbr = tokens[0].upper()
+
+    return team_abbr, direction
+
+
+def get_theme(bet: dict) -> str:
+    """Return the exposure theme for a bet."""
+    side = bet["side"].strip()
+    market = bet["market"].replace("alternate_", "")
+
+    # Handle team total bets like "ATL Over 4.5" or "Los Angeles Over 5.0"
+    if "team_totals" in market:
+        _, direction = parse_team_total_side(side)
+        if direction:
+            return direction
+
+    if side.startswith("Over"):
+        return "Over"
+    if side.startswith("Under"):
+        return "Under"
+
+    if "h2h" in market or "spreads" in market or "runline" in market:
+        tokens = side.split()
+        if tokens:
+            first = tokens[0]
+            if first.upper() in TEAM_ABBR_TO_NAME:
+                return first.upper()
+            if first.title() in TEAM_NAME_TO_ABBR:
+                return TEAM_NAME_TO_ABBR[first.title()]
+        for name in TEAM_NAME_TO_ABBR:
+            if side.startswith(name):
+                return name
+    return "Other"
+
+
+def get_theme_key(market: str, theme: str) -> str:
+    """Return a theme key combining theme name with a normalized market."""
+    key = normalize_market_key(market)
+    if key in {"total", "spread", "h2h"}:
+        return f"{theme}_{key}"
+    return f"{theme}_other"
+
+
+def normalize_segment(market: str) -> str:
+    """Return a unified segment tag from a raw market name."""
+    m = market.lower()
+    if "1st_3" in m:
+        return "1st_3"
+    if "1st_5" in m:
+        return "1st_5"
+    if "1st_7" in m:
+        return "1st_7"
+    if "1st_1" in m or "1st_inning" in m:
+        return "1st"
+    return "full_game"
+


### PR DESCRIPTION
## Summary
- extract theme helpers into `theme_utils`
- update `should_log_bet` to pull helpers from new module
- adjust `theme_exposure_tracker` to use `theme_utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb215ce0c832c87b30ec1c028c938