### PR TITLE
Fix theme tracker import for dispatch scripts

### DIFF
--- a/core/theme_exposure_tracker.py
+++ b/core/theme_exposure_tracker.py
@@ -3,7 +3,7 @@ import json
 import ast
 from typing import Dict
 
-from .theme_key_utils import make_theme_key, parse_theme_key
+from core.theme_key_utils import make_theme_key, parse_theme_key
 from core.theme_utils import get_theme, get_theme_key, normalize_segment
 
 from core.file_utils import with_locked_file


### PR DESCRIPTION
## Summary
- fix import path in `theme_exposure_tracker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb5eb49b4832cab2f4f861bf1f76f