### PR TITLE
Fix stake fallback in snapshot format

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1070,7 +1070,8 @@ def format_for_display(rows: list, include_movement: bool = False) -> pd.DataFra
         df["Stake"] = df.apply(_fmt_stake, axis=1)
     else:
         df["Stake"] = df.apply(
-            lambda row: f"{row.get('total_stake', row['stake']):.2f}u", axis=1
+            lambda row: f"{row.get('total_stake') or row.get('stake', 0.0):.2f}u",
+            axis=1,
         )
 
     if "snapshot_stake" in df.columns:


### PR DESCRIPTION
## Summary
- fix KeyError risk when formatting stake values

## Testing
- `python -m py_compile core/snapshot_core.py`

------
https://chatgpt.com/codex/tasks/task_e_685eba1e76bc832cafb3a5554e762386