### PR TITLE
Inline pending bet update before recheck

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -33,7 +33,8 @@ from pathlib import Path
 from datetime import datetime, timedelta
 from core.utils import now_eastern
 from core.odds_fetcher import fetch_all_market_odds, save_market_odds_to_file
-from cli.monitor_early_bets import recheck_pending_bets
+from cli.monitor_early_bets import recheck_pending_bets, update_pending_from_snapshot
+from core.snapshot_core import load_latest_snapshot
 
 EDGE_THRESHOLD = 0.05
 MIN_EV = 0.05
@@ -438,7 +439,14 @@ if initial_odds:
                 break
             time.sleep(0.2)
 
-        run_subprocess([PYTHON, "-m", "scripts.update_pending_from_snapshot"])
+        logger.info("\ud83d\udcc2 Updating pending bets from latest snapshot before recheck...")
+
+        # Load snapshot data
+        snapshot_rows = load_latest_snapshot()
+        # Update pending_bets.json in-place using snapshot
+        update_pending_from_snapshot(snapshot_rows)
+
+        logger.info("\u2705 Pending bets updated. Proceeding to recheck...")
         recheck_pending_bets()
 
 start_time = time.time()
@@ -510,7 +518,14 @@ while True:
                         break
                     time.sleep(0.2)
 
-                run_subprocess([PYTHON, "-m", "scripts.update_pending_from_snapshot"])
+                logger.info("\ud83d\udcc2 Updating pending bets from latest snapshot before recheck...")
+
+                # Load snapshot data
+                snapshot_rows = load_latest_snapshot()
+                # Update pending_bets.json in-place using snapshot
+                update_pending_from_snapshot(snapshot_rows)
+
+                logger.info("\u2705 Pending bets updated. Proceeding to recheck...")
                 recheck_pending_bets()
 
         last_log_time = now

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -11,7 +11,8 @@ import io
 import pandas as pd
 
 import requests
-from core.utils import post_with_retries
+from core.utils import post_with_retries, safe_load_json
+import glob
 
 try:
     import dataframe_image as dfi
@@ -66,6 +67,23 @@ MARKET_EVAL_TRACKER_BEFORE_UPDATE = copy.deepcopy(MARKET_EVAL_TRACKER)
 # === Console Output Controls ===
 MOVEMENT_LOG_LIMIT = 5
 movement_log_count = 0
+
+
+def load_latest_snapshot(folder: str = "backtest") -> list:
+    """Return rows from the most recent ``market_snapshot_*.json`` in ``folder``."""
+    pattern = os.path.join(folder, "market_snapshot_*.json")
+    files = glob.glob(pattern)
+    if not files:
+        logger.warning("⚠️ No snapshot files found in %s", folder)
+        return []
+
+    latest = max(files, key=os.path.getmtime)
+    data = safe_load_json(latest)
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return list(data.values())
+    return []
 
 
 


### PR DESCRIPTION
## Summary
- inline `update_pending_from_snapshot` into `auto_sim_and_log_loop`
- expose helpers in `monitor_early_bets` and `snapshot_core`
- update pending bets using in-process functions before running checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed592c49c832cb1d16cd63aab3b42