### PR TITLE
Show FV from blended probability

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -150,6 +150,25 @@ def main() -> None:
         logger.warning("⚠️ 'Market' column missing — cannot apply fallback filters.")
         return
 
+    columns = [
+        "Date",
+        "Time",
+        "Matchup",
+        "Market Class",
+        "Market",
+        "Bet",
+        "Book",
+        "Odds",
+        "Sim %",
+        "Mkt %",
+        "FV",
+        "EV",
+        "Stake",
+        "Logged?",
+    ]
+    columns = [c for c in columns if c in df.columns]
+    df = df[columns]
+
     if args.output_discord:
         webhook_main = os.getenv("DISCORD_BEST_BOOK_MAIN_WEBHOOK_URL")
         webhook_alt = os.getenv("DISCORD_BEST_BOOK_ALT_WEBHOOK_URL")

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -242,6 +242,26 @@ def main() -> None:
         logger.info("⚠️ No qualifying FV Drop rows with market movement to display.")
         return
 
+    columns = [
+        "Date",
+        "Time",
+        "Matchup",
+        "Market Class",
+        "Market",
+        "Bet",
+        "Book",
+        "Odds",
+        "Sim %",
+        "Mkt %",
+        "FV",
+        "EV",
+        "Stake",
+        "Logged?",
+    ]
+    columns = [c for c in columns if c in df_fv_filtered.columns]
+    df_fv_filtered = df_fv_filtered[columns]
+    df_fv_all = df_fv_all[columns]
+
     if args.output_discord:
         fv_drop_webhook = os.getenv("DISCORD_FV_DROP_WEBHOOK_URL")
         fv_drop_all_webhook = os.getenv("DISCORD_FV_DROP_ALL_WEBHOOK_URL")

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -145,6 +145,25 @@ def main() -> None:
         logger.warning("⚠️ 'Market' column missing — skipping live snapshot dispatch.")
         return
 
+    columns = [
+        "Date",
+        "Time",
+        "Matchup",
+        "Market Class",
+        "Market",
+        "Bet",
+        "Book",
+        "Odds",
+        "Sim %",
+        "Mkt %",
+        "FV",
+        "EV",
+        "Stake",
+        "Logged?",
+    ]
+    columns = [c for c in columns if c in df.columns]
+    df = df[columns]
+
     if args.output_discord:
         webhook_map = {
             "h2h": os.getenv("DISCORD_H2H_WEBHOOK_URL"),

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -171,6 +171,25 @@ def main() -> None:
         )
         return
 
+    columns = [
+        "Date",
+        "Time",
+        "Matchup",
+        "Market Class",
+        "Market",
+        "Bet",
+        "Book",
+        "Odds",
+        "Sim %",
+        "Mkt %",
+        "FV",
+        "EV",
+        "Stake",
+        "Logged?",
+    ]
+    columns = [c for c in columns if c in df.columns]
+    df = df[columns]
+
     if args.output_discord:
         webhook = PERSONAL_WEBHOOK_URL
 


### PR DESCRIPTION
## Summary
- compute blended FV as `1 / blended_prob`
- remove fallbacks to `fair_odds`
- standardize snapshot columns in dispatch scripts

## Testing
- `black core/dispatch_personal_snapshot.py core/dispatch_best_book_snapshot.py core/dispatch_fv_drop_snapshot.py core/dispatch_live_snapshot.py core/snapshot_core.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685edbe03b88832caf017f85220cabcc