### PR TITLE
Keep logged bets refreshed

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -126,8 +126,9 @@ def update_pending_from_snapshot(rows: list, path: str = PENDING_BETS_PATH) -> N
             rk = float(row.get("raw_kelly", 0))
         except Exception:
             continue
-        if logged or ev < 5.0 or rk < 1.0:
-            continue
+        # Refresh logged bets each loop instead of discarding them
+        if ev < 5.0 or rk < 1.0:
+            continue  # Still filter weak edges
         key = build_tracker_key(row.get("game_id"), row.get("market"), row.get("side"))
         entry = {
             "game_id": row.get("game_id"),

--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -43,8 +43,9 @@ def filter_rows(rows: list) -> list:
             rk = float(row.get("raw_kelly", 0))
         except Exception:
             continue
-        if logged or ev < 5.0 or rk < 1.0:
-            continue
+        # Allow logged bets so they remain in pending and stay refreshed
+        if ev < 5.0 or rk < 1.0:
+            continue  # Filter weak edges only
         filtered.append(row)
     return filtered
 


### PR DESCRIPTION
## Summary
- keep logged bets when saving pending bets from snapshots
- ensure logged bets are not filtered out in CLI tool and script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eea3cd02c832c957db6c14bda20a5