### PR TITLE
Force dispatch scripts to reload pending bets

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -4,10 +4,10 @@ import os
 import sys
 from core.bootstrap import *  # noqa
 
-"""Dispatch best-book snapshot from unified snapshot JSON."""
+"""Dispatch best-book snapshot from pending_bets.json."""
 
 import json
-from core.utils import safe_load_json
+from core.utils import parse_game_id
 from theme_exposure_tracker import build_theme_key
 import argparse
 from dotenv import load_dotenv
@@ -17,6 +17,7 @@ load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.book_helpers import filter_snapshot_rows, ensure_side
+from core.pending_bets import load_pending_bets
 from core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -25,23 +26,13 @@ logger = get_logger(__name__)
 logger.debug("✅ Loaded webhook: %s", os.getenv("DISCORD_BEST_BOOK_MAIN_WEBHOOK_URL"))
 
 
-def latest_snapshot_path(folder="backtest") -> str | None:
-    files = sorted(
-        [
-            f
-            for f in os.listdir(folder)
-            if f.startswith("market_snapshot_") and f.endswith(".json")
-        ],
-        reverse=True,
+def load_pending_rows() -> list:
+    """Return pending bets loaded from disk."""
+    pending = load_pending_bets()
+    rows = list(pending.values())
+    logger.info(
+        "📊 Rendering snapshot from %d entries in pending_bets.json", len(rows)
     )
-    return os.path.join(folder, files[0]) if files else None
-
-
-def load_rows(path: str) -> list:
-    rows = safe_load_json(path)
-    if rows is None:
-        logger.error("❌ Failed to load snapshot %s", path)
-        sys.exit(1)
     for r in rows:
         ensure_side(r)
     return rows
@@ -50,14 +41,15 @@ def load_rows(path: str) -> list:
 def filter_by_date(rows: list, date_str: str | None) -> list:
     if not date_str:
         return rows
-    return [r for r in rows if str(r.get("snapshot_for_date")) == date_str]
+    return [
+        r
+        for r in rows
+        if parse_game_id(str(r.get("game_id", ""))).get("date") == date_str
+    ]
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Dispatch best-book snapshot")
-    parser.add_argument(
-        "--snapshot-path", default=None, help="Path to unified snapshot JSON"
-    )
     parser.add_argument("--date", default=None, help="Filter by game date")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
@@ -86,12 +78,10 @@ def main() -> None:
     if args.min_ev > args.max_ev:
         args.max_ev = args.min_ev
 
-    path = args.snapshot_path or latest_snapshot_path()
-    if not path or not os.path.exists(path):
-        logger.error("❌ Snapshot not found: %s", path)
-        sys.exit(1)
-
-    rows = load_rows(path)
+    rows = load_pending_rows()
+    if not rows:
+        logger.warning("⚠️ pending_bets.json empty or not found – skipping dispatch")
+        return
 
     try:
         with open("logs/theme_exposure.json") as f:

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -4,10 +4,10 @@ import os
 import sys
 from core.bootstrap import *  # noqa
 
-"""Dispatch live snapshot from unified snapshot JSON."""
+"""Dispatch live snapshot from pending_bets.json."""
 
 import json
-from core.utils import safe_load_json
+from core.utils import parse_game_id
 from theme_exposure_tracker import build_theme_key
 import argparse
 from dotenv import load_dotenv
@@ -17,6 +17,7 @@ load_dotenv()
 
 from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.book_helpers import filter_snapshot_rows, ensure_side
+from core.pending_bets import load_pending_bets
 from core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -25,23 +26,13 @@ logger = get_logger(__name__)
 logger.debug("✅ Loaded webhook: %s", os.getenv("DISCORD_SPREADS_WEBHOOK_URL"))
 
 
-def latest_snapshot_path(folder="backtest") -> str | None:
-    files = sorted(
-        [
-            f
-            for f in os.listdir(folder)
-            if f.startswith("market_snapshot_") and f.endswith(".json")
-        ],
-        reverse=True,
+def load_pending_rows() -> list:
+    """Return pending bets loaded from disk."""
+    pending = load_pending_bets()
+    rows = list(pending.values())
+    logger.info(
+        "📊 Rendering snapshot from %d entries in pending_bets.json", len(rows)
     )
-    return os.path.join(folder, files[0]) if files else None
-
-
-def load_rows(path: str) -> list:
-    rows = safe_load_json(path)
-    if rows is None:
-        logger.error("❌ Failed to load snapshot %s", path)
-        sys.exit(1)
     for r in rows:
         ensure_side(r)
     return rows
@@ -50,14 +41,15 @@ def load_rows(path: str) -> list:
 def filter_by_date(rows: list, date_str: str | None) -> list:
     if not date_str:
         return rows
-    return [r for r in rows if str(r.get("snapshot_for_date")) == date_str]
+    return [
+        r
+        for r in rows
+        if parse_game_id(str(r.get("game_id", ""))).get("date") == date_str
+    ]
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Dispatch live snapshot")
-    parser.add_argument(
-        "--snapshot-path", default=None, help="Path to unified snapshot JSON"
-    )
     parser.add_argument("--date", default=None, help="Filter by game date")
     parser.add_argument("--output-discord", action="store_true")
     parser.add_argument(
@@ -80,12 +72,12 @@ def main() -> None:
     if args.min_ev > args.max_ev:
         args.max_ev = args.min_ev
 
-    path = args.snapshot_path or latest_snapshot_path()
-    if not path or not os.path.exists(path):
-        logger.error("❌ Snapshot not found: %s", path)
-        sys.exit(1)
-
-    rows = load_rows(path)
+    rows = load_pending_rows()
+    if not rows:
+        logger.warning(
+            "⚠️ pending_bets.json empty or not found – skipping dispatch"
+        )
+        return
 
     try:
         with open("logs/theme_exposure.json") as f:
@@ -99,7 +91,6 @@ def main() -> None:
         if "book" not in r and "best_book" in r:
             r["book"] = r["best_book"]
 
-    rows = [r for r in rows if "live" in r.get("snapshot_roles", [])]
     rows = filter_by_date(rows, args.date)
 
     rows = filter_snapshot_rows(rows, min_ev=args.min_ev)


### PR DESCRIPTION
## Summary
- refactor Discord snapshot dispatchers to load pending bets directly from `pending_bets.json`
- skip dispatch when the file is missing or empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eebd00280832ca9a705164461a12c