### PR TITLE
Keep logged bets in pending_bets

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -96,7 +96,7 @@ def merge_snapshot_pending(pending: dict, rows: list) -> dict:
     for r in rows:
         if not isinstance(r, dict):
             continue
-        if not r.get("queued_ts") or r.get("logged"):
+        if not r.get("queued_ts"):
             continue
         gid = r.get("game_id")
         market = r.get("market")


### PR DESCRIPTION
## Summary
- retain logged bets when merging snapshot data so their info is refreshed
- ensure pending bet filter only rejects weak edges

## Testing
- `pytest -q` *(fails: no tests run due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685eee8a4240832caa703d0bc8104ac0