### PR TITLE
Fix dropping of logged bets after game start

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -126,6 +126,12 @@ def update_pending_from_snapshot(rows: list, path: str = PENDING_BETS_PATH) -> N
             rk = float(row.get("raw_kelly", 0))
         except Exception:
             continue
+        try:
+            hours = float(row.get("hours_to_game", 0))
+            if logged and hours < 0:
+                continue  # drop logged bets for games in the past
+        except Exception:
+            pass
         # Refresh logged bets each loop instead of discarding them
         if ev < 5.0 or rk < 1.0:
             continue  # Still filter weak edges

--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -43,6 +43,12 @@ def filter_rows(rows: list) -> list:
             rk = float(row.get("raw_kelly", 0))
         except Exception:
             continue
+        try:
+            hours = float(row.get("hours_to_game", 0))
+            if logged and hours < 0:
+                continue  # drop logged bets for past games
+        except Exception:
+            pass
         # Allow logged bets so they remain in pending and stay refreshed
         if ev < 5.0 or rk < 1.0:
             continue  # Filter weak edges only


### PR DESCRIPTION
## Summary
- ensure logged bets are discarded only once the game has started
- apply logic in monitor_early_bets and the update_pending_from_snapshot utility

## Testing
- `pytest -q`
- `python -m py_compile scripts/update_pending_from_snapshot.py cli/monitor_early_bets.py`


------
https://chatgpt.com/codex/tasks/task_e_685ef091b004832cadfe6857f2fdb07d