### PR TITLE
Add safeguards for dispatch scripts

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -133,11 +133,11 @@ def main() -> None:
         logger.warning("⚠️ Snapshot DataFrame is empty — nothing to dispatch.")
         return
 
-    if "market" in df.columns and "Market" not in df.columns:
-        df["Market"] = df["market"]
+    if "market" in df.columns:
+        df["Market"] = df["market"].astype(str)
 
     if "Market" not in df.columns:
-        logger.warning("⚠️ 'Market' column missing — cannot apply fallback filters.")
+        logger.warning("⚠️ 'Market' column missing — skipping dispatch.")
         return
 
     columns = [
@@ -156,7 +156,12 @@ def main() -> None:
         "Stake",
         "Logged?",
     ]
-    columns = [c for c in columns if c in df.columns]
+    missing = [c for c in columns if c not in df.columns]
+    if missing:
+        logger.warning(
+            f"⚠️ Missing required columns: {missing} — skipping dispatch."
+        )
+        return
     df = df[columns]
 
     if args.output_discord:
@@ -179,6 +184,7 @@ def main() -> None:
                         .str.lower()
                         .str.startswith(("h2h", "spreads", "totals"), na=False)
                     ]
+                logger.info(f"🧾 Snapshot rows for 'main': {subset.shape[0]}")
                 logger.info(
                     "📡 Evaluating snapshot for: main → %s rows", subset.shape[0]
                 )
@@ -203,6 +209,7 @@ def main() -> None:
                         .str.lower()
                         .str.startswith(("h2h", "spreads", "totals"), na=False)
                     ]
+                logger.info(f"🧾 Snapshot rows for 'alt': {subset.shape[0]}")
                 logger.info(
                     "📡 Evaluating snapshot for: alternate → %s rows", subset.shape[0]
                 )

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -153,8 +153,12 @@ def main() -> None:
         logger.warning("⚠️ Snapshot DataFrame is empty — nothing to dispatch.")
         return
 
-    if "market" in df.columns and "Market" not in df.columns:
-        df["Market"] = df["market"]
+    if "market" in df.columns:
+        df["Market"] = df["market"].astype(str)
+
+    if "Market" not in df.columns:
+        logger.warning("⚠️ 'Market' column missing — skipping dispatch.")
+        return
 
     if "Market Class" not in df.columns:
         logger.warning(
@@ -178,14 +182,21 @@ def main() -> None:
         "Stake",
         "Logged?",
     ]
-    columns = [c for c in columns if c in df.columns]
+    missing = [c for c in columns if c not in df.columns]
+    if missing:
+        logger.warning(
+            f"⚠️ Missing required columns: {missing} — skipping dispatch."
+        )
+        return
     df = df[columns]
 
     if args.output_discord:
         webhook = PERSONAL_WEBHOOK_URL
 
         main_df = df[df["Market Class"] == "Main"]
+        logger.info(f"🧾 Snapshot rows for 'main': {main_df.shape[0]}")
         alt_df = df[df["Market Class"] == "Alt"]
+        logger.info(f"🧾 Snapshot rows for 'alt': {alt_df.shape[0]}")
 
         if not main_df.empty:
             logger.info(


### PR DESCRIPTION
## Summary
- enhance dispatch scripts to guard against missing columns and NaN filtering
- log row counts per role slice

## Testing
- `python -m py_compile core/dispatch_live_snapshot.py core/dispatch_personal_snapshot.py core/dispatch_best_book_snapshot.py core/dispatch_fv_drop_snapshot.py`
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe9633920832cba6fbee120088e03