### PR TITLE
Improve FV drop snapshot safety

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -586,6 +586,17 @@ def send_bet_snapshot_to_discord(
         )
         if resp:
             print(f"✅ Snapshot sent: {df.shape[0]} bets dispatched")
+            try:
+                data = resp.json()
+            except Exception:
+                data = {}
+            channel_id = data.get("channel_id")
+            message_id = data.get("id")
+            if channel_id:
+                print(f"🧩 Channel ID: {channel_id}")
+            if channel_id and message_id:
+                msg_url = f"https://discord.com/channels/{channel_id}/{message_id}"
+                print(f"🧩 Message URL: {msg_url}")
     except Exception as e:
         print(f"❌ Failed to send snapshot for {market_type}: {e}")
     finally:


### PR DESCRIPTION
## Summary
- add skip count logging in `dispatch_fv_drop_snapshot`
- coerce market column to string and ensure `Logged?` column exists
- allow forced dispatch when no qualifying rows
- log channel and message URL when sending snapshots

## Testing
- `python -m py_compile core/dispatch_fv_drop_snapshot.py core/snapshot_core.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860c5c2d430832ca77eff53dc7d211f