### PR TITLE
Remove force dispatch caption prefix

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -238,8 +238,6 @@ def main() -> None:
                 subset.shape[0],
             )
             title = "Best Book Snapshot"
-            if args.force_dispatch:
-                title = f"📸 Snapshot Test Mode — {title} (Forced Dispatch)"
             send_bet_snapshot_to_discord(
                 subset,
                 title,

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -363,8 +363,6 @@ def main() -> None:
         if fv_drop_webhook:
             if not df_fv_filtered.empty or args.force_dispatch:
                 title = "FV Drop (Primary)"
-                if args.force_dispatch:
-                    title = f"📸 Snapshot Test Mode — {title} (Forced Dispatch)"
                 send_bet_snapshot_to_discord(
                     df_fv_filtered,
                     title,
@@ -379,8 +377,6 @@ def main() -> None:
         if fv_drop_all_webhook:
             if not df_fv_all.empty or args.force_dispatch:
                 title = "FV Drop (All Allowed Books)"
-                if args.force_dispatch:
-                    title = f"📸 Snapshot Test Mode — {title} (Forced Dispatch)"
                 send_bet_snapshot_to_discord(
                     df_fv_all,
                     title,

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -204,8 +204,6 @@ def main() -> None:
         if unified_hook:
             logger.info("📡 Dispatching unified live snapshot (%s rows)", df.shape[0])
             title = "Live Snapshot"
-            if args.force_dispatch:
-                title = f"📸 Snapshot Test Mode — {title} (Forced Dispatch)"
             send_bet_snapshot_to_discord(
                 df,
                 title,
@@ -249,8 +247,6 @@ def main() -> None:
                 "📡 Dispatching %s live snapshot (%s rows)", label, subset.shape[0]
             )
             title = "Live Snapshot"
-            if args.force_dispatch:
-                title = f"📸 Snapshot Test Mode — {title} (Forced Dispatch)"
             send_bet_snapshot_to_discord(
                 subset,
                 title,

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -232,8 +232,6 @@ def main() -> None:
             return
         logger.info("📡 Dispatching unified personal snapshot (%s rows)", df.shape[0])
         title = "Personal Snapshot"
-        if args.force_dispatch:
-            title = f"📸 Snapshot Test Mode — {title} (Forced Dispatch)"
         send_bet_snapshot_to_discord(
             df,
             title,


### PR DESCRIPTION
## Summary
- simplify caption handling in dispatch scripts

## Testing
- `python -m py_compile core/dispatch_live_snapshot.py core/dispatch_fv_drop_snapshot.py core/dispatch_best_book_snapshot.py core/dispatch_personal_snapshot.py`


------
https://chatgpt.com/codex/tasks/task_e_6861860da114832c909402ffa1989c3a