### PR TITLE
Fix EV filtering for snapshot dispatch

### DIFF
--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -114,7 +114,8 @@ def main() -> None:
         logger.info("⏭️ Skip diagnostics: %s", dict(skip_counts))
 
     if "ev_percent" in df.columns:
-        df = df[(df["ev_percent"] >= args.min_ev) & (df["ev_percent"] <= args.max_ev)]
+        if not args.force_dispatch:
+            df = df[(df["ev_percent"] >= args.min_ev) & (df["ev_percent"] <= args.max_ev)]
         logger.info(
             "🧪 Dispatch filter: %d rows with %.1f ≤ EV%% ≤ %.1f",
             len(df),

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1206,6 +1206,8 @@ def format_for_display(rows: list, include_movement: bool = False) -> pd.DataFra
         "mkt_prob_display",
         "odds_display",
         "fv_display",
+        "ev_percent",
+        "raw_kelly",
         "sim_prob",
         "market_prob",
         "market_odds",


### PR DESCRIPTION
## Summary
- preserve `ev_percent` and `raw_kelly` when formatting snapshot rows
- skip EV% filtering when `--force-dispatch` is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862770aac9c832c99224006280855ed