### PR TITLE
Fix stake filter misalignment

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -143,19 +143,20 @@ def main() -> None:
             args.max_ev,
         )
 
+    df["__stake_check"] = 0.0
     if "total_stake" in df.columns:
-        stake_vals = pd.to_numeric(df["total_stake"], errors="coerce")
+        df["__stake_check"] = pd.to_numeric(df["total_stake"], errors="coerce")
     elif "stake" in df.columns:
-        stake_vals = pd.to_numeric(df["stake"], errors="coerce")
+        df["__stake_check"] = pd.to_numeric(df["stake"], errors="coerce")
     elif "snapshot_stake" in df.columns:
-        stake_vals = pd.to_numeric(df["snapshot_stake"], errors="coerce")
-    else:
-        stake_vals = pd.Series([0] * len(df))
+        df["__stake_check"] = pd.to_numeric(df["snapshot_stake"], errors="coerce")
+
     if "is_prospective" in df.columns:
-        mask = (stake_vals >= 1.0) | df["is_prospective"]
+        df = df[(df["__stake_check"] >= 1.0) | df["is_prospective"]]
     else:
-        mask = stake_vals >= 1.0
-    df = df[mask]
+        df = df[df["__stake_check"] >= 1.0]
+
+    df.drop(columns=["__stake_check"], inplace=True)
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -231,19 +231,20 @@ def main() -> None:
             args.max_ev,
         )
 
+    df["__stake_check"] = 0.0
     if "total_stake" in df.columns:
-        stake_vals = pd.to_numeric(df["total_stake"], errors="coerce")
+        df["__stake_check"] = pd.to_numeric(df["total_stake"], errors="coerce")
     elif "stake" in df.columns:
-        stake_vals = pd.to_numeric(df["stake"], errors="coerce")
+        df["__stake_check"] = pd.to_numeric(df["stake"], errors="coerce")
     elif "snapshot_stake" in df.columns:
-        stake_vals = pd.to_numeric(df["snapshot_stake"], errors="coerce")
-    else:
-        stake_vals = pd.Series([0] * len(df))
+        df["__stake_check"] = pd.to_numeric(df["snapshot_stake"], errors="coerce")
+
     if "is_prospective" in df.columns:
-        mask = (stake_vals >= 1.0) | df["is_prospective"]
+        df = df[(df["__stake_check"] >= 1.0) | df["is_prospective"]]
     else:
-        mask = stake_vals >= 1.0
-    df = df[mask]
+        df = df[df["__stake_check"] >= 1.0]
+
+    df.drop(columns=["__stake_check"], inplace=True)
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -123,19 +123,20 @@ def main() -> None:
             args.max_ev,
         )
 
+    df["__stake_check"] = 0.0
     if "total_stake" in df.columns:
-        stake_vals = pd.to_numeric(df["total_stake"], errors="coerce")
+        df["__stake_check"] = pd.to_numeric(df["total_stake"], errors="coerce")
     elif "stake" in df.columns:
-        stake_vals = pd.to_numeric(df["stake"], errors="coerce")
+        df["__stake_check"] = pd.to_numeric(df["stake"], errors="coerce")
     elif "snapshot_stake" in df.columns:
-        stake_vals = pd.to_numeric(df["snapshot_stake"], errors="coerce")
-    else:
-        stake_vals = pd.Series([0] * len(df))
+        df["__stake_check"] = pd.to_numeric(df["snapshot_stake"], errors="coerce")
+
     if "is_prospective" in df.columns:
-        mask = (stake_vals >= 1.0) | df["is_prospective"]
+        df = df[(df["__stake_check"] >= 1.0) | df["is_prospective"]]
     else:
-        mask = stake_vals >= 1.0
-    df = df[mask]
+        df = df[df["__stake_check"] >= 1.0]
+
+    df.drop(columns=["__stake_check"], inplace=True)
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -136,19 +136,20 @@ def main() -> None:
     if "ev_percent" in df.columns:
         df = df[(df["ev_percent"] >= args.min_ev) & (df["ev_percent"] <= args.max_ev)]
 
+    df["__stake_check"] = 0.0
     if "total_stake" in df.columns:
-        stake_vals = pd.to_numeric(df["total_stake"], errors="coerce")
+        df["__stake_check"] = pd.to_numeric(df["total_stake"], errors="coerce")
     elif "stake" in df.columns:
-        stake_vals = pd.to_numeric(df["stake"], errors="coerce")
+        df["__stake_check"] = pd.to_numeric(df["stake"], errors="coerce")
     elif "snapshot_stake" in df.columns:
-        stake_vals = pd.to_numeric(df["snapshot_stake"], errors="coerce")
-    else:
-        stake_vals = pd.Series([0] * len(df))
+        df["__stake_check"] = pd.to_numeric(df["snapshot_stake"], errors="coerce")
+
     if "is_prospective" in df.columns:
-        mask = (stake_vals >= 1.0) | df["is_prospective"]
+        df = df[(df["__stake_check"] >= 1.0) | df["is_prospective"]]
     else:
-        mask = stake_vals >= 1.0
-    df = df[mask]
+        df = df[df["__stake_check"] >= 1.0]
+
+    df.drop(columns=["__stake_check"], inplace=True)
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])


### PR DESCRIPTION
## Summary
- update stake filtering logic in dispatch scripts to avoid misaligned boolean mask

## Testing
- `python -m py_compile core/dispatch_best_book_snapshot.py core/dispatch_live_snapshot.py core/dispatch_fv_drop_snapshot.py core/dispatch_personal_snapshot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627c9f5f40832cad3ecb07ce5c7739