### PR TITLE
Update pending snapshot fields

### DIFF
--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -76,8 +76,9 @@ def build_pending(rows: list, tracker: dict) -> dict:
             "date_simulated": row.get("date_simulated"),
             "skip_reason": row.get("skip_reason"),
             "logged": row.get("logged", False),
+            "market_class": row.get("market_class") or "main",
         }
-        role = _assign_snapshot_role(entry)
+        role = _assign_snapshot_role(row)
         entry["snapshot_role"] = role
         roles = []
         if isinstance(row.get("snapshot_roles"), list):


### PR DESCRIPTION
## Summary
- ensure `market_class` defaults to `main` when building pending bets
- compute `snapshot_role` from the source snapshot row
- populate `snapshot_roles` from previous roles plus required entries

## Testing
- `python -m py_compile scripts/update_pending_from_snapshot.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6863bc55c0b0832cb6ba0a31473c3887