### PR TITLE
Ensure market_class persists in pending bet updates

### DIFF
--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -76,7 +76,7 @@ def build_pending(rows: list, tracker: dict) -> dict:
             "date_simulated": row.get("date_simulated"),
             "skip_reason": row.get("skip_reason"),
             "logged": row.get("logged", False),
-            "market_class": row.get("market_class") or "main",
+            "market_class": row.get("market_class", "main"),
         }
         role = _assign_snapshot_role(row)
         entry["snapshot_role"] = role


### PR DESCRIPTION
## Summary
- default `market_class` in `build_pending`
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863c45b3a8c832c8c4c71b44c6ff72f