### PR TITLE
Fix missing market_class in pending snapshot rows

### DIFF
--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -76,8 +76,8 @@ def build_pending(rows: list, tracker: dict) -> dict:
             "date_simulated": row.get("date_simulated"),
             "skip_reason": row.get("skip_reason"),
             "logged": row.get("logged", False),
-            "market_class": row.get("market_class", "main"),
         }
+        entry["market_class"] = row.get("market_class", "main").lower()
         role = _assign_snapshot_role(row)
         entry["snapshot_role"] = role
         roles = []


### PR DESCRIPTION
## Summary
- ensure `market_class` gets added to pending bet entries

## Testing
- `python -m py_compile scripts/update_pending_from_snapshot.py core/pending_bets.py`

------
https://chatgpt.com/codex/tasks/task_e_6863cb48a560832cb918c41acf98aae3