### PR TITLE
Use raw_kelly for snapshot stake filtering

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -149,20 +149,9 @@ def main() -> None:
             args.max_ev,
         )
 
-    df["__stake_check"] = 0.0
-    if "total_stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["total_stake"], errors="coerce")
-    elif "stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["stake"], errors="coerce")
-    elif "snapshot_stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["snapshot_stake"], errors="coerce")
-
-    if "is_prospective" in df.columns:
-        df = df[(df["__stake_check"] >= 1.0) | df["is_prospective"]]
-    else:
-        df = df[df["__stake_check"] >= 1.0]
-
-    df.drop(columns=["__stake_check"], inplace=True)
+    if "raw_kelly" in df.columns:
+        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
+        df = df[stake_vals >= 1.0]
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -237,20 +237,9 @@ def main() -> None:
             args.max_ev,
         )
 
-    df["__stake_check"] = 0.0
-    if "total_stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["total_stake"], errors="coerce")
-    elif "stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["stake"], errors="coerce")
-    elif "snapshot_stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["snapshot_stake"], errors="coerce")
-
-    if "is_prospective" in df.columns:
-        df = df[(df["__stake_check"] >= 1.0) | df["is_prospective"]]
-    else:
-        df = df[df["__stake_check"] >= 1.0]
-
-    df.drop(columns=["__stake_check"], inplace=True)
+    if "raw_kelly" in df.columns:
+        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
+        df = df[stake_vals >= 1.0]
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -123,20 +123,9 @@ def main() -> None:
             args.max_ev,
         )
 
-    df["__stake_check"] = 0.0
-    if "total_stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["total_stake"], errors="coerce")
-    elif "stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["stake"], errors="coerce")
-    elif "snapshot_stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["snapshot_stake"], errors="coerce")
-
-    if "is_prospective" in df.columns:
-        df = df[(df["__stake_check"] >= 1.0) | df["is_prospective"]]
-    else:
-        df = df[df["__stake_check"] >= 1.0]
-
-    df.drop(columns=["__stake_check"], inplace=True)
+    if "raw_kelly" in df.columns:
+        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
+        df = df[stake_vals >= 1.0]
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -142,20 +142,9 @@ def main() -> None:
     if "ev_percent" in df.columns:
         df = df[(df["ev_percent"] >= args.min_ev) & (df["ev_percent"] <= args.max_ev)]
 
-    df["__stake_check"] = 0.0
-    if "total_stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["total_stake"], errors="coerce")
-    elif "stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["stake"], errors="coerce")
-    elif "snapshot_stake" in df.columns:
-        df["__stake_check"] = pd.to_numeric(df["snapshot_stake"], errors="coerce")
-
-    if "is_prospective" in df.columns:
-        df = df[(df["__stake_check"] >= 1.0) | df["is_prospective"]]
-    else:
-        df = df[df["__stake_check"] >= 1.0]
-
-    df.drop(columns=["__stake_check"], inplace=True)
+    if "raw_kelly" in df.columns:
+        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
+        df = df[stake_vals >= 1.0]
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])


### PR DESCRIPTION
## Summary
- simplify snapshot stake filtering
- require `raw_kelly >= 1.0` in best-book, live, personal and FV drop snapshots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d6fd6ff0832cae84f8595a62e2ae