### PR TITLE
Use raw kelly for stake filters

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -149,9 +149,19 @@ def main() -> None:
             args.max_ev,
         )
 
-    if "raw_kelly" in df.columns:
-        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
-        df = df[stake_vals >= 1.0]
+    print(f"🧪 Pre-stake filter row count: {df.shape[0]}")
+    try:
+        print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
+    except Exception:
+        pass
+    stake_vals = pd.to_numeric(df.get("raw_kelly", 0), errors="coerce").fillna(0)
+    mask = (stake_vals >= 1.0) | df.get("is_prospective", False)
+    df = df[mask]
+    print(f"🧪 Post-stake filter row count: {df.shape[0]}")
+    try:
+        print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
+    except Exception:
+        pass
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -237,9 +237,19 @@ def main() -> None:
             args.max_ev,
         )
 
-    if "raw_kelly" in df.columns:
-        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
-        df = df[stake_vals >= 1.0]
+    print(f"🧪 Pre-stake filter row count: {df.shape[0]}")
+    try:
+        print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
+    except Exception:
+        pass
+    stake_vals = pd.to_numeric(df.get("raw_kelly", 0), errors="coerce").fillna(0)
+    mask = (stake_vals >= 1.0) | df.get("is_prospective", False)
+    df = df[mask]
+    print(f"🧪 Post-stake filter row count: {df.shape[0]}")
+    try:
+        print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
+    except Exception:
+        pass
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -123,9 +123,19 @@ def main() -> None:
             args.max_ev,
         )
 
-    if "raw_kelly" in df.columns:
-        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
-        df = df[stake_vals >= 1.0]
+    print(f"🧪 Pre-stake filter row count: {df.shape[0]}")
+    try:
+        print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
+    except Exception:
+        pass
+    stake_vals = pd.to_numeric(df.get("raw_kelly", 0), errors="coerce").fillna(0)
+    mask = (stake_vals >= 1.0) | df.get("is_prospective", False)
+    df = df[mask]
+    print(f"🧪 Post-stake filter row count: {df.shape[0]}")
+    try:
+        print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
+    except Exception:
+        pass
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -142,9 +142,19 @@ def main() -> None:
     if "ev_percent" in df.columns:
         df = df[(df["ev_percent"] >= args.min_ev) & (df["ev_percent"] <= args.max_ev)]
 
-    if "raw_kelly" in df.columns:
-        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
-        df = df[stake_vals >= 1.0]
+    print(f"🧪 Pre-stake filter row count: {df.shape[0]}")
+    try:
+        print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
+    except Exception:
+        pass
+    stake_vals = pd.to_numeric(df.get("raw_kelly", 0), errors="coerce").fillna(0)
+    mask = (stake_vals >= 1.0) | df.get("is_prospective", False)
+    df = df[mask]
+    print(f"🧪 Post-stake filter row count: {df.shape[0]}")
+    try:
+        print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
+    except Exception:
+        pass
 
     if all(c in df.columns for c in ["game_id", "market", "side", "book"]):
         df = df.drop_duplicates(subset=["game_id", "market", "side", "book"])


### PR DESCRIPTION
## Summary
- derive Stake from `raw_kelly` in snapshot formatting
- filter dispatch DataFrames by `raw_kelly` and show diagnostic output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d51acd2c832c902d1b6f5f840009