### PR TITLE
Add debug prints and case-insensitive market class mapping

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -219,6 +219,12 @@ def main() -> None:
         return
     df = df[columns]
 
+    # Debug: inspect market class values before role filtering
+    try:
+        print(df[["Market", "market_class", "Market Class"]].drop_duplicates())
+    except Exception as e:
+        print(f"Debug print failed: {e}")
+
     if args.output_discord:
         main_hook = os.getenv("DISCORD_BEST_BOOK_MAIN_WEBHOOK_URL")
         alt_hook = os.getenv("DISCORD_BEST_BOOK_ALT_WEBHOOK_URL")

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1088,7 +1088,7 @@ def format_for_display(rows: list, include_movement: bool = False) -> pd.DataFra
     if "market_class" not in df.columns:
         df["market_class"] = "main"
     df["Market Class"] = (
-        df["market_class"].map({"alternate": "Alt", "main": "Main"}).fillna("❓")
+        df["market_class"].str.lower().map({"alternate": "Alt", "main": "Main"}).fillna("❓")
     )
 
     if "label" not in df.columns:


### PR DESCRIPTION
## Summary
- ensure `format_for_display` maps market class case-insensitively
- add debug output in `dispatch_best_book_snapshot.py` before role filtering

## Testing
- `python -m py_compile core/dispatch_best_book_snapshot.py core/snapshot_core.py`

------
https://chatgpt.com/codex/tasks/task_e_6864de20ccd4832cb4c74d1e86809358