### PR TITLE
Gracefully handle malformed recovery tracker during auto loop

### DIFF
--- a/core/market_eval_tracker.py
+++ b/core/market_eval_tracker.py
@@ -53,12 +53,20 @@ def load_tracker(path: str = TRACKER_PATH) -> Dict[str, dict]:
         try:
             with open(recovery_path, "r") as f:
                 recovery = json.load(f)
+        except json.JSONDecodeError as e:
+            logger.error(
+                "❌ Failed to parse recovery tracker — skipping merge (%s line %s column %s)",
+                recovery_path,
+                e.lineno,
+                e.colno,
+            )
+        except Exception as e:  # Catch other unexpected errors
+            logger.error("❌ Failed to merge recovery tracker: %s", e)
+        else:
             if isinstance(recovery, dict):
                 data.update(recovery)
             os.remove(recovery_path)
             print(f"\U0001F4E4 Merged recovery tracker with {len(recovery)} entries")
-        except Exception as e:
-            logger.error("❌ Failed to merge recovery tracker: %s", e)
     return data
 
 


### PR DESCRIPTION
## Summary
- handle JSONDecodeError when merging recovery tracker

## Testing
- `python -m py_compile core/market_eval_tracker.py`
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68658c307b4c832c8bcf7cc7884c304b