### PR TITLE
Fix stake filter fallback in dispatch scripts

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -156,7 +156,14 @@ def main() -> None:
         print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
     except Exception:
         pass
-    stake_vals = pd.to_numeric(df.get("raw_kelly", 0), errors="coerce").fillna(0)
+    # Stake filtering (fallback from stake to raw_kelly)
+    if "stake" in df.columns:
+        stake_vals = pd.to_numeric(df["stake"], errors="coerce")
+    elif "raw_kelly" in df.columns:
+        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
+    else:
+        stake_vals = pd.Series([0] * len(df))
+
     mask = (stake_vals >= 1.0) | df.get("is_prospective", False)
     df = df[mask]
     print(f"🧪 Post-stake filter row count: {df.shape[0]}")

--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -242,7 +242,14 @@ def main() -> None:
         print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
     except Exception:
         pass
-    stake_vals = pd.to_numeric(df.get("raw_kelly", 0), errors="coerce").fillna(0)
+    # Stake filtering (fallback from stake to raw_kelly)
+    if "stake" in df.columns:
+        stake_vals = pd.to_numeric(df["stake"], errors="coerce")
+    elif "raw_kelly" in df.columns:
+        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
+    else:
+        stake_vals = pd.Series([0] * len(df))
+
     mask = (stake_vals >= 1.0) | df.get("is_prospective", False)
     df = df[mask]
     print(f"🧪 Post-stake filter row count: {df.shape[0]}")

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -128,7 +128,14 @@ def main() -> None:
         print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
     except Exception:
         pass
-    stake_vals = pd.to_numeric(df.get("raw_kelly", 0), errors="coerce").fillna(0)
+    # Stake filtering (fallback from stake to raw_kelly)
+    if "stake" in df.columns:
+        stake_vals = pd.to_numeric(df["stake"], errors="coerce")
+    elif "raw_kelly" in df.columns:
+        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
+    else:
+        stake_vals = pd.Series([0] * len(df))
+
     mask = (stake_vals >= 1.0) | df.get("is_prospective", False)
     df = df[mask]
     print(f"🧪 Post-stake filter row count: {df.shape[0]}")

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -147,7 +147,14 @@ def main() -> None:
         print(df[["market", "side", "ev_percent", "raw_kelly"]].head())
     except Exception:
         pass
-    stake_vals = pd.to_numeric(df.get("raw_kelly", 0), errors="coerce").fillna(0)
+    # Stake filtering (fallback from stake to raw_kelly)
+    if "stake" in df.columns:
+        stake_vals = pd.to_numeric(df["stake"], errors="coerce")
+    elif "raw_kelly" in df.columns:
+        stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
+    else:
+        stake_vals = pd.Series([0] * len(df))
+
     mask = (stake_vals >= 1.0) | df.get("is_prospective", False)
     df = df[mask]
     print(f"🧪 Post-stake filter row count: {df.shape[0]}")


### PR DESCRIPTION
## Summary
- handle `stake` column in snapshot dispatch scripts before falling back to `raw_kelly`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686601a91fb4832cb2194f99314a25b9