### PR TITLE
Preserve baseline consensus on snapshot updates

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -133,7 +133,9 @@ def merge_snapshot_pending(pending: dict, rows: list) -> dict:
 def update_pending_from_snapshot(rows: list, path: str = PENDING_BETS_PATH) -> None:
     """Overwrite ``pending_bets.json`` with entries built from ``rows``."""
     tracker = load_market_conf_tracker()
+    # Load existing pending bets so we can preserve any established baselines
     pending: dict = {}
+    existing_pending = load_pending_bets(path)
     for row in rows:
         try:
             logged = bool(row.get("logged"))
@@ -180,6 +182,13 @@ def update_pending_from_snapshot(rows: list, path: str = PENDING_BETS_PATH) -> N
             cp = tracker[key].get("consensus_prob")
             if cp is not None:
                 entry["baseline_consensus_prob"] = cp
+
+        # Preserve existing baseline_consensus_prob if already set
+        existing_row = existing_pending.get(key)
+        if existing_row:
+            baseline = existing_row.get("baseline_consensus_prob")
+            if baseline is not None:
+                entry["baseline_consensus_prob"] = baseline
         pending[key] = entry
 
     if pending:


### PR DESCRIPTION
## Summary
- load existing pending bets when building pending list from a snapshot
- keep baseline_consensus_prob from existing entry instead of overwriting it

## Testing
- `pytest -q` *(fails: no tests ran, network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6867c0c690e0832ca4526e1a474b60ff