### PR TITLE
Refactor exposure key utility

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -19,6 +19,7 @@ from core.should_log_bet import (
     normalize_segment,
 )
 from core.theme_key_utils import make_theme_key
+from core.exposure_utils import get_exposure_key
 from dotenv import load_dotenv
 
 from core.market_eval_tracker import (
@@ -1384,31 +1385,6 @@ def send_discord_notification(row, skipped_bets=None):
             print(f"🔍 Message that failed: {message}")
 
 
-def get_exposure_key(row):
-    market = row["market"]
-    game_id = row["game_id"]
-    side = remap_side_key(row["side"])
-
-    market_type = normalize_market_key(market)
-    if market_type not in {"total", "spread", "h2h"}:
-        market_type = "other"
-
-    segment = normalize_segment(market)
-
-    for team in TEAM_NAME_TO_ABBR:
-        if side.startswith(team):
-            theme = team
-            break
-    else:
-        if "Over" in side:
-            theme = "Over"
-        elif "Under" in side:
-            theme = "Under"
-        else:
-            theme = "Other"
-
-    theme_key = f"{theme}_{market_type}"
-    return make_theme_key(game_id, theme_key, segment)
 
 
 def write_to_csv(

--- a/core/exposure_utils.py
+++ b/core/exposure_utils.py
@@ -1,0 +1,51 @@
+from core.theme_key_utils import make_theme_key
+from core.theme_utils import normalize_market_key, normalize_segment
+from core.utils import TEAM_ABBR_TO_NAME, TEAM_NAME_TO_ABBR
+
+
+def remap_side_key(side: str) -> str:
+    """Expand team abbreviations and preserve Over/Under labels."""
+    # If already a full team name (e.g., 'Pittsburgh Pirates'), keep it
+    if side in TEAM_NAME_TO_ABBR:
+        return side
+
+    # Check for abbreviation + number (like 'PIT+0.5' or 'MIA-1.5')
+    for abbr, full_name in TEAM_ABBR_TO_NAME.items():
+        if side.startswith(abbr):
+            rest = side[len(abbr):].strip()
+            return f"{full_name} {rest}".strip()
+
+    # If it's an Over/Under line like 'Over 4.5', 'Under 7.0', leave unchanged
+    if side.startswith("Over") or side.startswith("Under"):
+        return side
+
+    # Fallback — if unknown, return side as-is
+    return side
+
+
+def get_exposure_key(row: dict) -> str:
+    """Return a key for exposure tracking based on market and side."""
+    market = row["market"]
+    game_id = row["game_id"]
+    side = remap_side_key(row["side"])
+
+    market_type = normalize_market_key(market)
+    if market_type not in {"total", "spread", "h2h"}:
+        market_type = "other"
+
+    segment = normalize_segment(market)
+
+    for team in TEAM_NAME_TO_ABBR:
+        if side.startswith(team):
+            theme = team
+            break
+    else:
+        if "Over" in side:
+            theme = "Over"
+        elif "Under" in side:
+            theme = "Under"
+        else:
+            theme = "Other"
+
+    theme_key = f"{theme}_{market_type}"
+    return make_theme_key(game_id, theme_key, segment)

--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -31,7 +31,7 @@ import csv
 import os
 
 from core.theme_key_utils import make_theme_key, theme_key_equals
-from cli.log_betting_evals import get_exposure_key
+from core.exposure_utils import get_exposure_key
 from core.theme_utils import (
     normalize_market_key,
     parse_team_total_side,

--- a/scripts/reconcile_theme_exposure.py
+++ b/scripts/reconcile_theme_exposure.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from core.theme_key_utils import make_theme_key
 
-from cli.log_betting_evals import get_exposure_key
+from core.exposure_utils import get_exposure_key
 from core.theme_exposure_tracker import TRACKER_PATH, load_tracker, save_tracker
 
 CSV_PATH = os.path.join("logs", "market_evals.csv")


### PR DESCRIPTION
## Summary
- move `get_exposure_key` into new module `core/exposure_utils`
- import the helper from the new module across the repo
- delete old definition from `log_betting_evals`

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c5ff1390832caa5bb56eb7c74915