### PR TITLE
Infer market_class for pending bets

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -18,6 +18,7 @@ from core.pending_bets import (
     save_pending_bets,
     PENDING_BETS_PATH,
     validate_pending_bets,
+    infer_market_class,
 )
 from core.snapshot_core import _assign_snapshot_role
 from core.market_eval_tracker import (
@@ -110,6 +111,8 @@ def merge_snapshot_pending(pending: dict, rows: list) -> dict:
         key = f"{gid}:{market}:{side}"
         base = merged.get(key, {})
         bet = _clean_snapshot_row(r)
+        if "market_class" not in bet:
+            bet["market_class"] = infer_market_class(market)
         # Assign snapshot role if missing
         if "snapshot_role" not in bet:
             bet["snapshot_role"] = _assign_snapshot_role(bet)
@@ -167,6 +170,8 @@ def update_pending_from_snapshot(rows: list, path: str = PENDING_BETS_PATH) -> N
             "skip_reason": row.get("skip_reason"),
             "logged": row.get("logged", False),
         }
+        if "market_class" not in entry:
+            entry["market_class"] = infer_market_class(entry.get("market"))
         role = _assign_snapshot_role(entry)
         entry["snapshot_role"] = role
         roles = []

--- a/core/pending_bets.py
+++ b/core/pending_bets.py
@@ -13,6 +13,23 @@ from core.time_utils import compute_hours_to_game
 from core.lock_utils import with_locked_file
 from core.snapshot_core import _assign_snapshot_role
 
+
+def infer_market_class(market: str) -> str:
+    """Return market class inferred from ``market``."""
+    if not isinstance(market, str):
+        return "unknown"
+    market = market.lower()
+    if market.startswith("totals"):
+        return "totals"
+    elif market.startswith("spreads"):
+        return "spreads"
+    elif market == "h2h":
+        return "h2h"
+    elif market == "team_totals":
+        return "totals"
+    else:
+        return "unknown"
+
 logger = get_logger(__name__)
 
 
@@ -96,7 +113,7 @@ def queue_pending_bet(bet: dict, path: str = PENDING_BETS_PATH) -> None:
 
     # Ensure required snapshot metadata is present
     if "market_class" not in bet_copy:
-        bet_copy["market_class"] = "main"
+        bet_copy["market_class"] = infer_market_class(bet_copy.get("market"))
     role = _assign_snapshot_role(bet_copy)
     bet_copy["snapshot_role"] = role
     roles = set(bet_copy.get("snapshot_roles") or [])

--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -11,6 +11,7 @@ import glob
 from core.market_eval_tracker import build_tracker_key
 from core.utils import safe_load_json
 from core.snapshot_core import _assign_snapshot_role
+from core.pending_bets import infer_market_class
 from cli.log_betting_evals import load_market_conf_tracker
 
 SNAPSHOT_DIR = os.path.join("backtest")
@@ -77,8 +78,9 @@ def build_pending(rows: list, tracker: dict) -> dict:
             "skip_reason": row.get("skip_reason"),
             "logged": row.get("logged", False),
         }
-        entry["market_class"] = row.get("market_class", "main").lower()
-        role = _assign_snapshot_role(row)
+        if "market_class" not in entry:
+            entry["market_class"] = infer_market_class(entry.get("market"))
+        role = _assign_snapshot_role(entry)
         entry["snapshot_role"] = role
         roles = []
         if isinstance(row.get("snapshot_roles"), list):


### PR DESCRIPTION
## Summary
- add `infer_market_class` helper in `pending_bets`
- ensure `queue_pending_bet` infers `market_class`
- propagate inference to `merge_snapshot_pending` and `update_pending_from_snapshot`
- use inference when generating pending bets from snapshot script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867c9e7f2dc832c883ba040983e576e