### PR TITLE
Refactor pending bet market_class logic

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -18,8 +18,8 @@ from core.pending_bets import (
     save_pending_bets,
     PENDING_BETS_PATH,
     validate_pending_bets,
-    infer_market_class,
 )
+from core.market_normalizer import normalize_market_key
 from core.snapshot_core import _assign_snapshot_role
 from core.market_eval_tracker import (
     load_tracker as load_eval_tracker,
@@ -112,7 +112,8 @@ def merge_snapshot_pending(pending: dict, rows: list) -> dict:
         base = merged.get(key, {})
         bet = _clean_snapshot_row(r)
         if "market_class" not in bet:
-            bet["market_class"] = infer_market_class(market)
+            meta = normalize_market_key(market or "")
+            bet["market_class"] = meta.get("market_class", "main")
         # Assign snapshot role if missing
         if "snapshot_role" not in bet:
             bet["snapshot_role"] = _assign_snapshot_role(bet)
@@ -171,7 +172,8 @@ def update_pending_from_snapshot(rows: list, path: str = PENDING_BETS_PATH) -> N
             "logged": row.get("logged", False),
         }
         if "market_class" not in entry:
-            entry["market_class"] = infer_market_class(entry.get("market"))
+            meta = normalize_market_key(entry.get("market", ""))
+            entry["market_class"] = meta.get("market_class", "main")
         role = _assign_snapshot_role(entry)
         entry["snapshot_role"] = role
         roles = []

--- a/core/pending_bets.py
+++ b/core/pending_bets.py
@@ -12,6 +12,7 @@ from core.logger import get_logger
 from core.time_utils import compute_hours_to_game
 from core.lock_utils import with_locked_file
 from core.snapshot_core import _assign_snapshot_role
+from core.market_normalizer import normalize_market_key
 
 
 def infer_market_class(market: str) -> str:
@@ -113,7 +114,8 @@ def queue_pending_bet(bet: dict, path: str = PENDING_BETS_PATH) -> None:
 
     # Ensure required snapshot metadata is present
     if "market_class" not in bet_copy:
-        bet_copy["market_class"] = infer_market_class(bet_copy.get("market"))
+        meta = normalize_market_key(bet_copy.get("market", ""))
+        bet_copy["market_class"] = meta.get("market_class", "main")
     role = _assign_snapshot_role(bet_copy)
     bet_copy["snapshot_role"] = role
     roles = set(bet_copy.get("snapshot_roles") or [])

--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -11,7 +11,7 @@ import glob
 from core.market_eval_tracker import build_tracker_key
 from core.utils import safe_load_json
 from core.snapshot_core import _assign_snapshot_role
-from core.pending_bets import infer_market_class
+from core.market_normalizer import normalize_market_key
 from cli.log_betting_evals import load_market_conf_tracker
 
 SNAPSHOT_DIR = os.path.join("backtest")
@@ -79,7 +79,8 @@ def build_pending(rows: list, tracker: dict) -> dict:
             "logged": row.get("logged", False),
         }
         if "market_class" not in entry:
-            entry["market_class"] = infer_market_class(entry.get("market"))
+            meta = normalize_market_key(entry.get("market", ""))
+            entry["market_class"] = meta.get("market_class", "main")
         role = _assign_snapshot_role(entry)
         entry["snapshot_role"] = role
         roles = []


### PR DESCRIPTION
## Summary
- normalize `market_class` via `normalize_market_key` when queuing pending bets
- preserve correct market_class when merging or rebuilding pending bets

## Testing
- `pytest -q`
- `python -m py_compile core/pending_bets.py cli/monitor_early_bets.py scripts/update_pending_from_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_6867f4ec87a0832ca9f28369dd412517