### PR TITLE
Add market_group tracking for pending bet updates

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -18,6 +18,7 @@ from core.pending_bets import (
     save_pending_bets,
     PENDING_BETS_PATH,
     validate_pending_bets,
+    infer_market_class,
 )
 from core.market_normalizer import normalize_market_key
 from core.snapshot_core import _assign_snapshot_role
@@ -114,6 +115,7 @@ def merge_snapshot_pending(pending: dict, rows: list) -> dict:
         if "market_class" not in bet:
             meta = normalize_market_key(market or "")
             bet["market_class"] = meta.get("market_class", "main")
+        bet["market_group"] = infer_market_class(market)
         # Assign snapshot role if missing
         if "snapshot_role" not in bet:
             bet["snapshot_role"] = _assign_snapshot_role(bet)
@@ -171,6 +173,7 @@ def update_pending_from_snapshot(rows: list, path: str = PENDING_BETS_PATH) -> N
             "skip_reason": row.get("skip_reason"),
             "logged": row.get("logged", False),
         }
+        entry["market_group"] = infer_market_class(entry.get("market"))
         if "market_class" not in entry:
             meta = normalize_market_key(entry.get("market", ""))
             entry["market_class"] = meta.get("market_class", "main")

--- a/core/pending_bets.py
+++ b/core/pending_bets.py
@@ -116,6 +116,8 @@ def queue_pending_bet(bet: dict, path: str = PENDING_BETS_PATH) -> None:
     if "market_class" not in bet_copy:
         meta = normalize_market_key(bet_copy.get("market", ""))
         bet_copy["market_class"] = meta.get("market_class", "main")
+    if "market_group" not in bet_copy:
+        bet_copy["market_group"] = infer_market_class(bet_copy.get("market"))
     role = _assign_snapshot_role(bet_copy)
     bet_copy["snapshot_role"] = role
     roles = set(bet_copy.get("snapshot_roles") or [])

--- a/scripts/update_pending_from_snapshot.py
+++ b/scripts/update_pending_from_snapshot.py
@@ -12,6 +12,7 @@ from core.market_eval_tracker import build_tracker_key
 from core.utils import safe_load_json
 from core.snapshot_core import _assign_snapshot_role
 from core.market_normalizer import normalize_market_key
+from core.pending_bets import infer_market_class
 from cli.log_betting_evals import load_market_conf_tracker
 
 SNAPSHOT_DIR = os.path.join("backtest")
@@ -78,6 +79,7 @@ def build_pending(rows: list, tracker: dict) -> dict:
             "skip_reason": row.get("skip_reason"),
             "logged": row.get("logged", False),
         }
+        entry["market_group"] = infer_market_class(entry.get("market"))
         if "market_class" not in entry:
             meta = normalize_market_key(entry.get("market", ""))
             entry["market_class"] = meta.get("market_class", "main")


### PR DESCRIPTION
## Summary
- augment pending bet utilities to store `market_group` using `infer_market_class`
- carry `market_group` through snapshot merging and rebuild scripts

## Testing
- `python -m py_compile cli/monitor_early_bets.py core/pending_bets.py scripts/update_pending_from_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_6867fc2866f8832cb18889f53fd897e0