### PR TITLE
Update backfill script to normalize market class

### DIFF
--- a/backfill_market_class.py
+++ b/backfill_market_class.py
@@ -1,27 +1,27 @@
 from core.pending_bets import (
     load_pending_bets,
     save_pending_bets,
-    infer_market_class,
     PENDING_BETS_PATH,
 )
+from core.market_normalizer import normalize_market_key
 
 
 def backfill(path: str = PENDING_BETS_PATH) -> int:
-    """Backfill missing market_class fields in pending bets."""
+    """Backfill ``market_class`` for each pending bet entry."""
     pending = load_pending_bets(path)
     updated = 0
+
     for row in pending.values():
-        if not row.get("market_class"):
-            row["market_class"] = infer_market_class(row.get("market"))
+        meta = normalize_market_key(row.get("market"))
+        mclass = meta.get("market_class", "main")
+        if row.get("market_class") != mclass:
+            row["market_class"] = mclass
             updated += 1
-    if updated:
-        save_pending_bets(pending, path)
+
+    save_pending_bets(pending, path)
     return updated
 
 
 if __name__ == "__main__":
     count = backfill()
-    if count:
-        print(f"\u2705 Backfilled 'market_class' for {count} entries.")
-    else:
-        print("\u2705 All entries already have 'market_class'. Nothing to patch.")
+    print(f"\u2705 Backfilled market_class for {count} rows in {PENDING_BETS_PATH}")


### PR DESCRIPTION
## Summary
- update `backfill_market_class.py` to use `normalize_market_key`
- always save updated rows and print summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868066ee438832cb976dba8989575ea