### PR TITLE
Ensure pending bets keep baseline consensus probability

### DIFF
--- a/cli/monitor_early_bets.py
+++ b/cli/monitor_early_bets.py
@@ -198,6 +198,13 @@ def update_pending_from_snapshot(rows: list, path: str = PENDING_BETS_PATH) -> N
             if baseline is not None:
                 entry["baseline_consensus_prob"] = baseline
 
+        # Fallback to market_prob or consensus_prob when no baseline is present
+        baseline = entry.get("baseline_consensus_prob")
+        if baseline is None:
+            baseline = row.get("market_prob") or row.get("consensus_prob")
+            if baseline is not None:
+                entry["baseline_consensus_prob"] = baseline
+
         pending[key] = entry
 
     if pending:


### PR DESCRIPTION
## Summary
- enforce fallback in `update_pending_from_snapshot`

## Testing
- `pytest -q` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68680a0fa574832cab1db264708dfb35