### PR TITLE
Normalize market_class before saving pending bets

### DIFF
--- a/core/pending_bets.py
+++ b/core/pending_bets.py
@@ -66,6 +66,11 @@ def load_pending_bets(path: str = PENDING_BETS_PATH) -> dict:
 
 def save_pending_bets(pending: dict, path: str = PENDING_BETS_PATH) -> None:
     """Persist ``pending`` to ``path`` atomically using a lock."""
+    from core.market_normalizer import normalize_market_key
+
+    for row in pending.values():
+        market = row.get("market", "")
+        row["market_class"] = normalize_market_key(market).get("market_class", "main")
     os.makedirs(os.path.dirname(path), exist_ok=True)
     lock = f"{path}.lock"
     tmp = f"{path}.tmp"


### PR DESCRIPTION
## Summary
- enforce final market_class normalization in `save_pending_bets`

## Testing
- `python -m py_compile core/pending_bets.py`

------
https://chatgpt.com/codex/tasks/task_e_6868729a08f4832c9a3692719bc7ce3b