### PR TITLE
Stop writing market_conf_tracker.json

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -142,7 +142,6 @@ def save_market_conf_tracker(tracker: dict, path: str = MARKET_CONF_TRACKER_PATH
 
 import copy
 from datetime import datetime
-from core.market_conf_tracker import save_tracker as save_conf_tracker
 
 # Load market confirmation tracker
 MARKET_CONF_TRACKER = load_market_conf_tracker()
@@ -1578,18 +1577,19 @@ def write_to_csv(
                 current_consensus_prob = (
                     new_conf_val if new_conf_val is not None else new_prob
                 )
-                if (
-                    current_consensus_prob is not None
-                    and baseline_tracker.get(tracker_key, {}).get("consensus_prob") is None
-                ):
-                    baseline_tracker[tracker_key] = {
-                        "consensus_prob": current_consensus_prob,
-                        "timestamp": datetime.utcnow().isoformat(),
-                    }
-                    save_conf_tracker(baseline_tracker)
-                    print(
-                        f"🆕 Baseline stored for {tracker_key} → {current_consensus_prob:.4f}"
-                    )
+                # Disabled write to market_conf_tracker.json during snapshot migration
+                # if (
+                #     current_consensus_prob is not None
+                #     and baseline_tracker.get(tracker_key, {}).get("consensus_prob") is None
+                # ):
+                #     baseline_tracker[tracker_key] = {
+                #         "consensus_prob": current_consensus_prob,
+                #         "timestamp": datetime.utcnow().isoformat(),
+                #     }
+                #     save_conf_tracker(baseline_tracker)
+                #     print(
+                #         f"🆕 Baseline stored for {tracker_key} → {current_consensus_prob:.4f}"
+                #     )
             movement = track_and_update_market_movement(
                 row,
                 MARKET_EVAL_TRACKER,
@@ -3134,12 +3134,13 @@ def process_theme_logged_bets(
         except Exception as e:  # pragma: no cover - unexpected save failure
             logger.warning("\u26a0\ufe0f Failed to save market eval tracker: %s", e)
 
-        try:
-            save_market_conf_tracker(MARKET_CONF_TRACKER)
-        except Exception as e:
-            logger.warning(
-                "\u26a0\ufe0f Failed to save market confirmation tracker: %s", e
-            )
+        # Disabled save during snapshot migration; tracker persistence handled elsewhere
+        # try:
+        #     save_market_conf_tracker(MARKET_CONF_TRACKER)
+        # except Exception as e:
+        #     logger.warning(
+        #         "\u26a0\ufe0f Failed to save market confirmation tracker: %s", e
+        #     )
 
     if not config.DEBUG_MODE:
         print(


### PR DESCRIPTION
## Summary
- avoid persisting market confirmation tracker
- stop writing baseline data for new entries

## Testing
- `pytest -q`
- `python -m py_compile cli/log_betting_evals.py`
- `find . -name '*.py' -not -path '*/\.*' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6868d882fac8832cba5e790d58dcc2a7