### PR TITLE
Fix missing baseline consensus probability in snapshots

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -117,6 +117,14 @@ def warn_missing_baselines(rows: list) -> None:
             pass
 
 
+def ensure_baseline_consensus_prob(rows: list) -> None:
+    """Populate ``baseline_consensus_prob`` when missing."""
+    for row in rows:
+        key = f"{row.get('game_id')}:{row.get('market')}:{row.get('side')}"
+        if "baseline_consensus_prob" not in row or row["baseline_consensus_prob"] is None:
+            row["baseline_consensus_prob"] = row.get("consensus_prob") or row.get("market_prob")
+
+
 def format_percentage(val: Optional[float]) -> str:
     """Return a percentage string like ``41.2%`` or ``–``."""
     try:
@@ -1609,6 +1617,7 @@ def expand_snapshot_rows_with_kelly(
                 deduped.append(row)
                 seen.add(key)
 
+    ensure_baseline_consensus_prob(deduped)
     warn_missing_baselines(deduped)
     save_tracker(MARKET_EVAL_TRACKER)
     return deduped

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -27,6 +27,7 @@ from core.snapshot_core import (
     MARKET_EVAL_TRACKER_BEFORE_UPDATE,
     expand_snapshot_rows_with_kelly,
     _assign_snapshot_role,
+    ensure_baseline_consensus_prob,
 )
 from core.market_eval_tracker import load_tracker, save_tracker
 from core.pending_bets import load_pending_bets
@@ -351,6 +352,8 @@ def main() -> None:
         out_dir = "backtest"
         final_path = os.path.join(out_dir, f"market_snapshot_{timestamp}.json")
         tmp_path = os.path.join(out_dir, f"market_snapshot_{timestamp}.tmp")
+
+        ensure_baseline_consensus_prob(all_rows)
 
         os.makedirs(out_dir, exist_ok=True)
         with open(tmp_path, "w") as f:


### PR DESCRIPTION
## Summary
- ensure every snapshot row has `baseline_consensus_prob`
- propagate baseline field when generating snapshots and when updating pending bets

## Testing
- `pytest -q`
- `python -m py_compile core/snapshot_core.py core/unified_snapshot_generator.py scripts/update_pending_from_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_6868e6ea76a8832caf4245fd4d27deb8