### PR TITLE
Ensure new bets update movement tracker

### DIFF
--- a/core/market_movement_tracker.py
+++ b/core/market_movement_tracker.py
@@ -150,8 +150,8 @@ def track_and_update_market_movement(
     entry.update(movement)
     entry["prev_market_odds"] = prev_market_odds
 
-    # Only update tracker if a meaningful change occurred
-    if movement.get("mkt_movement") == "same" and all(
+    # Only update tracker if a meaningful change occurred for existing entries
+    if prior is not None and movement.get("mkt_movement") == "same" and all(
         movement.get(k) == "same"
         for k in [
             "ev_movement",


### PR DESCRIPTION
## Summary
- update `track_and_update_market_movement` so new markets write to the tracker even if movement is `same`

## Testing
- `python -m py_compile core/market_movement_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_686991c168f4832ca3099caa3ff0b509