### PR TITLE
Fix pending bet filter logic

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -113,12 +113,20 @@ def _pending_rows_for_date(date_str: str, min_ev: float = 5.0) -> list:
             continue
 
         try:
-            ev = float(bet.get("ev_percent", 0))
-            rk = float(bet.get("raw_kelly", 0))
+            ev = float(bet.get("ev_percent", 0) or 0)
         except Exception:
-            continue
+            ev = 0.0
+        try:
+            rk = float(bet.get("raw_kelly", 0) or 0)
+        except Exception:
+            rk = 0.0
+        try:
+            stake_val = float(bet.get("stake", rk) or rk)
+        except Exception:
+            stake_val = rk
 
-        if ev < min_ev or rk < 1.0:
+        # Skip if EV is below threshold and both Kelly and stake are < 1u
+        if ev < 5.0 and rk < 1.0 and stake_val < 1.0:
             continue
 
         row = bet.copy()


### PR DESCRIPTION
## Summary
- update `_pending_rows_for_date()` filtering logic to only skip when EV is below 5% **and** both stake and raw Kelly are under 1u
- safely cast float values when parsing pending rows

## Testing
- `python -m py_compile core/unified_snapshot_generator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a405cf74832c8a2d35da9e41cc75