### PR TITLE
Update pending bet state and snapshot filter logic

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1607,6 +1607,10 @@ def expand_snapshot_rows_with_kelly(
             row["label"] = "🔍" if row.get("is_prospective") else "🟢"
             row["skip_reason"] = bet.get("skip_reason", None)
             row["logged"] = bet.get("logged", False)
+            row["movement_confirmed"] = bet.get("movement_confirmed", False)
+            row["visible_in_snapshot"] = bet.get("visible_in_snapshot", True)
+            if "last_skip_reason" in bet:
+                row["last_skip_reason"] = bet["last_skip_reason"]
 
             role = _assign_snapshot_role(row)
             row["snapshot_role"] = role


### PR DESCRIPTION
## Summary
- track new pending bet fields for snapshot visibility
- persist pending bets without `skip_reason`
- preserve snapshot state when updating from snapshots
- filter FV Drop snapshot rows based on baseline movement and visibility
- surface new fields when generating snapshot rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa9603a30832c96d96d5b2ab438bd