### PR TITLE
Update skip logic for movement confirmation

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1607,7 +1607,7 @@ def write_to_csv(
             annotate_display_deltas(row, prior_row)
             row["_movement_str"] = row.get("mkt_prob_display")
             row["_movement"] = movement
-            row["skip_reason"] = SkipReason.MARKET_NOT_MOVED.value
+            row["last_skip_reason"] = SkipReason.MARKET_NOT_MOVED.value
             return None
         elif new_prob <= prior_prob:
             print("⛔ Market probability did not improve — skipping.")
@@ -1624,7 +1624,7 @@ def write_to_csv(
                     "status": "pending",
                     "timestamp": datetime.now().isoformat(),
                 }
-            row["skip_reason"] = SkipReason.MARKET_NOT_MOVED.value
+            row["last_skip_reason"] = SkipReason.MARKET_NOT_MOVED.value
             return None
         elif (new_prob - prior_prob) < threshold:
             delta = new_prob - prior_prob
@@ -1644,7 +1644,7 @@ def write_to_csv(
                     "status": "pending",
                     "timestamp": datetime.now().isoformat(),
                 }
-            row["skip_reason"] = SkipReason.MARKET_NOT_MOVED.value
+            row["last_skip_reason"] = SkipReason.MARKET_NOT_MOVED.value
             return None
 
     # Clean up non-persistent keys


### PR DESCRIPTION
## Summary
- make movement confirmation update `movement_confirmed` field
- record transient skip reason in `last_skip_reason`
- queue early bets with movement status information
- stop persisting `market_not_moved` skip reason when logging

## Testing
- `pytest -q`
- `python -m py_compile core/should_log_bet.py cli/log_betting_evals.py core/pending_bets.py`

------
https://chatgpt.com/codex/tasks/task_e_686abd50e634832ca53b3de187bec5cd