### PR TITLE
Fix Status column check before DataFrames defined

### DIFF
--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -322,10 +322,7 @@ def main() -> None:
         "Stake",
         "Logged?",
     ]
-    if "Status" in df_fv_all.columns:
-        columns.append("Status")
-    if "Status" in df_fv_filtered.columns:
-        columns.append("Status")
+    # ✅ Ensure df_fv_all exists before referencing
     if "Status" in df.columns:
         columns.append("Status")
     missing = [c for c in columns if c not in df.columns]
@@ -377,6 +374,8 @@ def main() -> None:
         "Stake",
         "Logged?",
     ]
+    if "Status" in df_fv_filtered.columns or "Status" in df_fv_all.columns:
+        columns.append("Status")
     missing = [c for c in columns if c not in df_fv_filtered.columns]
     missing_all = [c for c in columns if c not in df_fv_all.columns]
     if missing:


### PR DESCRIPTION
## Summary
- avoid using df_fv_all and df_fv_filtered before definition in `dispatch_fv_drop_snapshot.py`
- only append `Status` column when present in the active DataFrame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac953680c832c941689d6247a7059