### PR TITLE
Switch dispatch scripts to snapshot file

### DIFF
--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 from core.config import DEBUG_MODE, VERBOSE_MODE
 import os
-import sys
 from core.bootstrap import *  # noqa
 
-"""Dispatch personal-book snapshot from pending_bets.json."""
-from core.utils import parse_game_id
+"""Dispatch personal-book snapshot using the latest snapshot file."""
+from core.utils import parse_game_id, safe_load_json
 
 import argparse
 from typing import List
@@ -20,7 +19,7 @@ from core.snapshot_core import format_for_display, send_bet_snapshot_to_discord
 from core.logger import get_logger
 from core.book_whitelist import ALLOWED_BOOKS
 from core.book_helpers import ensure_side
-from core.pending_bets import load_pending_bets
+from core.snapshot_tracker_loader import find_latest_market_snapshot_path
 
 logger = get_logger(__name__)
 
@@ -33,13 +32,11 @@ PERSONAL_WEBHOOK_URL = os.getenv(
 )
 
 
-def load_pending_rows() -> list:
-    """Return pending bets loaded from disk."""
-    pending = load_pending_bets()
-    rows = list(pending.values())
-    logger.info(
-        "📊 Rendering snapshot from %d entries in pending_bets.json", len(rows)
-    )
+def load_latest_snapshot_rows() -> list:
+    """Return snapshot rows from the most recent snapshot file."""
+    path = find_latest_market_snapshot_path("backtest")
+    rows = safe_load_json(path) if path else []
+    logger.info("📊 Loaded %d snapshot rows from %s", len(rows), path)
     for r in rows:
         ensure_side(r)
     return rows
@@ -94,11 +91,15 @@ def main() -> None:
     if args.min_ev > args.max_ev:
         args.max_ev = args.min_ev
 
-    rows = load_pending_rows()
+    rows = load_latest_snapshot_rows()
     if not rows:
-        logger.warning(
-            "⚠️ pending_bets.json empty or not found – skipping dispatch"
-        )
+        logger.warning("⚠️ No snapshot rows found – skipping dispatch")
+        return
+
+    rows = [r for r in rows if "personal" in (r.get("snapshot_roles") or [])]
+    logger.info("🧾 Snapshot rows for role='personal': %d", len(rows))
+    if not rows:
+        logger.warning("⚠️ No snapshot rows for role='personal' — skipping dispatch")
         return
 
     for r in rows:


### PR DESCRIPTION
## Summary
- load snapshot rows from latest `market_snapshot_*.json`
- remove any reference to `pending_bets.json`
- filter dispatches by snapshot role

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686af7461e1c832ca62b7a535e33cd02