### PR TITLE
Refactor logging evaluation helper

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -327,7 +327,7 @@ from core.time_utils import compute_hours_to_game
 
 
 # === Staking Logic Refactor ===
-from core.should_log_bet import should_log_bet
+from core.logging_helpers import evaluate_snapshot_row_for_logging
 from core.market_eval_tracker import (
     load_tracker as load_eval_tracker,
     save_tracker,
@@ -2976,14 +2976,11 @@ def process_theme_logged_bets(
         assert best_row.get("side"), f"Missing 'side' for {best_row}"
 
         try:
-            result = write_to_csv(
+            result = evaluate_snapshot_row_for_logging(
                 best_row,
-                "logs/market_evals.csv",
-                existing,
-                session_exposure,
                 existing_exposure,
-                dry_run=dry_run,
-                force_log=force_log,
+                MARKET_EVAL_TRACKER,
+                existing,
             )
             final_rows.append(best_row)
         except Exception as e:  # pragma: no cover - unexpected failure
@@ -3003,13 +3000,6 @@ def process_theme_logged_bets(
                 ensure_consensus_books(best_row)
                 skipped_bets.append(best_row)
 
-            if not result.get("skip_reason") and result.get("side"):
-                record_successful_log(result, existing, existing_exposure)
-            else:
-                logger.warning(
-                    "❌ Skipping tracker update: result was skipped or malformed → %s",
-                    result,
-                )
         else:
             print(
                 f"⛔ CSV Log Failed → {best_row['game_id']} | {best_row['market']} | {best_row['side']}"

--- a/core/logging_helpers.py
+++ b/core/logging_helpers.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+
+from core.should_log_bet import should_log_bet
+from cli.log_betting_evals import (
+    write_to_csv,
+    record_successful_log,
+)
+
+
+def evaluate_snapshot_row_for_logging(
+    row: dict,
+    theme_stakes: dict,
+    eval_tracker: dict,
+    existing: dict,
+) -> dict | None:
+    """Evaluate a snapshot row and write to CSV if it qualifies.
+
+    Parameters
+    ----------
+    row : dict
+        Snapshot row to evaluate.
+    theme_stakes : dict
+        Current theme exposure totals.
+    eval_tracker : dict
+        Tracker used for movement confirmation.
+    existing : dict
+        Existing stakes keyed by ``(game_id, market, side)``.
+
+    Returns
+    -------
+    dict | None
+        Result from :func:`write_to_csv` when the bet is logged or the
+        evaluation dictionary when skipped. ``None`` if evaluation failed.
+    """
+    evaluation = should_log_bet(
+        row.copy(),
+        theme_stakes,
+        verbose=False,
+        eval_tracker=eval_tracker,
+        existing_csv_stakes=existing,
+    )
+
+    if not evaluation:
+        return None
+
+    if evaluation.get("log") and not evaluation.get("skip_reason"):
+        session_exposure = defaultdict(set)
+        result = write_to_csv(
+            evaluation,
+            "logs/market_evals.csv",
+            existing,
+            session_exposure,
+            theme_stakes,
+        )
+        if result and not result.get("skip_reason"):
+            record_successful_log(result, existing, theme_stakes)
+        return result
+
+    return evaluation


### PR DESCRIPTION
## Summary
- add `evaluate_snapshot_row_for_logging` utility
- use new helper for monitoring script
- route final log step through helper in CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b180f5008832ca8854efb2053ee5a