### PR TITLE
Add advanced debugging for odds lookup and movement

### DIFF
--- a/core/market_normalizer.py
+++ b/core/market_normalizer.py
@@ -6,13 +6,29 @@ from core.utils import (
 )
 
 
-def normalize_market_key(market: str) -> dict:
+def normalize_market_key(
+    market: str,
+    *,
+    side: str | None = None,
+    game_id: str | None = None,
+    market_odds: dict | None = None,
+    debug: bool = False,
+) -> dict:
     """Return metadata derived from a market key."""
     market = market or ""
     mkey = _normalize_market_key_str(market)
     segment = classify_market_segment(mkey)
     market_class = "alternate" if "alternate" in market else "main"
     label = get_segment_label(mkey, "")
+
+    if debug:
+        found = False
+        if isinstance(market_odds, dict):
+            found = mkey in market_odds
+        print(
+            f"[Normalize Debug] game_id={game_id} market={market} side={side} -> {mkey} | found={found}"
+        )
+
     return {"segment": segment, "market_class": market_class, "label": label}
 
 


### PR DESCRIPTION
## Summary
- extend `lookup_fallback_odds` with optional verbose diagnostics
- allow detailed normalization logging in `market_normalizer`
- print market movement confirmation info during snapshot generation
- provide CLI flags to debug missing odds and movement
- surface nearby odds keys when lookups fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686baeacb30c832ca06927bb077a9f40