### PR TITLE
Add debug prints for fallback lookup

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1577,6 +1577,13 @@ def write_to_csv(
     if "market_prob" not in row and "consensus_prob" in row:
         row["market_prob"] = row["consensus_prob"]
     new_prob = row.get("market_prob")
+    if DEBUG and "baseline_consensus_prob" in row and "market_prob" in row:
+        base = row.get("baseline_consensus_prob")
+        current = row.get("market_prob")
+        delta = round(current - base, 4) if base is not None and current is not None else "?"
+        print(
+            f"[confirmation_debug] {row['game_id']} | {row['market']} | {row['side']} — baseline: {base}, current: {current}, delta: {delta}"
+        )
     hours_to_game = row.get("hours_to_game", 8)
 
     threshold = market_prob_increase_threshold

--- a/core/utils.py
+++ b/core/utils.py
@@ -1073,6 +1073,9 @@ def lookup_fallback_odds(
         if debug:
             print(f"[Fallback Debug] Exact match for {game_id}")
         return (row, game_id) if return_key else row
+    else:
+        if debug:
+            print(f"[fallback_debug] No exact match for {game_id}. Searching fuzzy matches...")
 
     # ✅ Step 2: strip time suffix and look for matching prefixes
     if "-T" not in game_id:
@@ -1129,6 +1132,7 @@ def lookup_fallback_odds(
             print(
                 f"[Fallback Debug] Using fallback {best_key} ({best_delta if best_delta is not None else '?'}m)"
             )
+            print(f"[fallback_debug] Matched fallback key: {best_key} for {game_id}")
         row = fallback_odds.get(best_key)
         return (row, best_key) if return_key else row
 


### PR DESCRIPTION
## Summary
- add additional fallback_debug prints in `lookup_fallback_odds`
- print baseline vs current market probability delta when DEBUG is enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbe3ac670832c95809cc71f5c0718