### PR TITLE
Improve fallback odds debug output and return tuple

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -259,7 +259,7 @@ def get_closest_odds(game_id: str, market_odds: dict, max_delta: int = 2, debug:
         return market_odds[canon_id]
 
     odds_row, matched = lookup_fallback_odds(
-        canon_id, market_odds, max_delta=max_delta, return_key=True, debug=debug
+        canon_id, market_odds, max_delta=max_delta, debug=debug
     )
 
     if odds_row is None:

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -107,7 +107,7 @@ def build_snapshot_rows(sim_data: dict, odds_json: dict, min_ev: float = 0.01):
     if VERBOSE or DEBUG:
         for game_id in sim_data.keys():
             print(f"\U0001F50D Evaluating {game_id}")
-            if lookup_fallback_odds(game_id, odds_json):
+            if lookup_fallback_odds(game_id, odds_json)[0]:
                 print(f"\u2705 Matched odds for {game_id}")
             else:
                 print(f"\u274C No odds found for {game_id}")
@@ -349,7 +349,7 @@ def build_snapshot_for_date(
     if odds_data is None:
         odds = fetch_market_odds_from_api(list(sims.keys()))
     else:
-        odds = {gid: lookup_fallback_odds(gid, odds_data) for gid in sims.keys()}
+        odds = {gid: lookup_fallback_odds(gid, odds_data)[0] for gid in sims.keys()}
 
     for gid in sims.keys():
         if gid not in odds or odds.get(gid) is None:

--- a/tests/test_lookup_fallback_odds.py
+++ b/tests/test_lookup_fallback_odds.py
@@ -6,14 +6,18 @@ def test_lookup_fallback_odds_exact():
     odds = {
         "2025-07-07-TOR@CWS-T1941": {"val": 1},
     }
-    assert lookup_fallback_odds("2025-07-07-TOR@CWS-T1941", odds) == {"val": 1}
+    row, key = lookup_fallback_odds("2025-07-07-TOR@CWS-T1941", odds)
+    assert row == {"val": 1}
+    assert key == "2025-07-07-TOR@CWS-T1941"
 
 
 def test_lookup_fallback_odds_fuzzy_single():
     odds = {
         "2025-07-07-TOR@CWS-T1941": {"val": 1},
     }
-    assert lookup_fallback_odds("2025-07-07-TOR@CWS-T1940", odds) == {"val": 1}
+    row, key = lookup_fallback_odds("2025-07-07-TOR@CWS-T1940", odds)
+    assert row == {"val": 1}
+    assert key == "2025-07-07-TOR@CWS-T1941"
 
 
 def test_lookup_fallback_odds_choose_smallest_delta():
@@ -22,11 +26,14 @@ def test_lookup_fallback_odds_choose_smallest_delta():
         "2025-07-07-TOR@CWS-T1941": {"k": "b"},
         "2025-07-07-TOR@CWS-T2000": {"k": "c"},
     }
-    assert lookup_fallback_odds("2025-07-07-TOR@CWS-T1940", odds) == {"k": "a"}
+    row, key = lookup_fallback_odds("2025-07-07-TOR@CWS-T1940", odds)
+    assert row == {"k": "a"}
+    assert key == "2025-07-07-TOR@CWS-T1939"
 
 
 def test_lookup_fallback_odds_none():
     odds = {
         "2025-07-07-TOR@CWS-T2000": {"k": "c"},
     }
-    assert lookup_fallback_odds("2025-07-08-TOR@CWS-T1940", odds) is None
+    row, key = lookup_fallback_odds("2025-07-08-TOR@CWS-T1940", odds)
+    assert row is None and key is None


### PR DESCRIPTION
## Summary
- add richer debugging to `lookup_fallback_odds`
- return `(row, key)` tuple from `lookup_fallback_odds`
- update usages and tests for the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc7545a24832c91431b40cd87b476