### PR TITLE
Improve baseline consensus handling

### DIFF
--- a/core/market_movement_tracker.py
+++ b/core/market_movement_tracker.py
@@ -191,6 +191,9 @@ def track_and_update_market_movement(
         "best_book": entry.get("best_book"),
         "raw_sportsbook": current_raw,
         "prev_raw_sportsbook": prev_raw,
+        "baseline_consensus_prob": prior.get("baseline_consensus_prob")
+        if prior.get("baseline_consensus_prob") is not None
+        else entry.get("baseline_consensus_prob"),
     }
 
     changed_fields = []

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -514,12 +514,12 @@ def main() -> None:
         final_path = os.path.join(out_dir, f"market_snapshot_{timestamp}.json")
         tmp_path = os.path.join(out_dir, f"market_snapshot_{timestamp}.tmp")
 
-        # 🧩 Enrich: baseline
-        ensure_baseline_consensus_prob(all_rows)
-
         # 🔁 Merge persistent fields from prior snapshot
         prior_map = _load_prior_snapshot_map(out_dir)
         _merge_persistent_fields(all_rows, prior_map)
+
+        # 🧩 Enrich: baseline
+        ensure_baseline_consensus_prob(all_rows, MARKET_EVAL_TRACKER_BEFORE_UPDATE)
 
         all_rows = [sanitize_json_row(r) for r in all_rows]
 


### PR DESCRIPTION
## Summary
- store baseline consensus probability in the market movement tracker
- derive baseline from tracker or prior snapshot when populating snapshot rows
- merge persistent fields before baseline enrichment so rows can pull previous data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf431edbc832ca5b7dde79b89bcde