### PR TITLE
Fix consensus prob fallback and tracker baseline updates

### DIFF
--- a/core/market_movement_tracker.py
+++ b/core/market_movement_tracker.py
@@ -167,16 +167,26 @@ def track_and_update_market_movement(
     entry.update(movement)
     entry["prev_market_odds"] = prev_market_odds
 
+    baseline_missing = (
+        prior.get("baseline_consensus_prob") is None
+        and entry.get("baseline_consensus_prob") is not None
+    )
+
     # Only update tracker if a meaningful change occurred for existing entries
-    if prior is not None and movement.get("mkt_movement") == "same" and all(
-        movement.get(k) == "same"
-        for k in [
-            "ev_movement",
-            "fv_movement",
-            "odds_movement",
-            "stake_movement",
-            "sim_movement",
-        ]
+    if (
+        prior is not None
+        and movement.get("mkt_movement") == "same"
+        and all(
+            movement.get(k) == "same"
+            for k in [
+                "ev_movement",
+                "fv_movement",
+                "odds_movement",
+                "stake_movement",
+                "sim_movement",
+            ]
+        )
+        and not baseline_missing
     ):
         return movement
 

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -987,6 +987,8 @@ def build_snapshot_rows(
                 label=lookup_side,
             )
             consensus_prob = result.get("consensus_prob")
+            if consensus_prob is None:
+                consensus_prob = market_entry.get("consensus_prob")
             book_odds_list = list(result.get("bookwise_probs", {}).values())
 
             market_clean = matched_key.replace("alternate_", "")


### PR DESCRIPTION
## Summary
- fallback to odds-provided consensus when devig fails
- ensure baseline_consensus_prob persists even when no movement detected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c03083534832cb58e20ddec8abd26