### PR TITLE
Remove redundant baseline enrichment

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1695,7 +1695,6 @@ def expand_snapshot_rows_with_kelly(
                 deduped.append(row)
                 seen.add(key)
 
-    ensure_baseline_consensus_prob(deduped)
     warn_missing_baselines(deduped)
     save_tracker(MARKET_EVAL_TRACKER)
     return deduped


### PR DESCRIPTION
## Summary
- drop baseline enrichment inside `expand_snapshot_rows_with_kelly`
- keep enrichment step after `_merge_persistent_fields`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c128a89fc832cb5dfa7230c12eb05