### PR TITLE
Add baseline prob mismatch warning

### DIFF
--- a/core/market_movement_tracker.py
+++ b/core/market_movement_tracker.py
@@ -206,6 +206,13 @@ def track_and_update_market_movement(
         else entry.get("baseline_consensus_prob"),
     }
 
+    if (
+        prior.get("baseline_consensus_prob") is not None
+        and prior.get("baseline_consensus_prob")
+        != entry.get("baseline_consensus_prob")
+    ):
+        logger.warning("⚠️ baseline_consensus_prob mismatch for %s", key)
+
     changed_fields = []
 
     for field, val in tracker_entry.items():


### PR DESCRIPTION
## Summary
- warn when baseline consensus differs from prior value in market movement tracker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c24e4b748832cbe265e06159b05dc