### PR TITLE
Update baseline consensus logic in deprecated/test scripts

### DIFF
--- a/deprecated/update_pending_from_snapshot.py
+++ b/deprecated/update_pending_from_snapshot.py
@@ -87,7 +87,8 @@ def build_pending(rows: list, tracker: dict) -> dict:
             baseline = tracker[key].get("consensus_prob")
 
         if baseline is None:
-            baseline = row.get("consensus_prob") or row.get("market_prob")
+            # baseline_consensus_prob = original implied probability when bet first appeared; never overwritten
+            baseline = row.get("consensus_prob")
 
         if baseline is not None:
             row["baseline_consensus_prob"] = baseline

--- a/tests/test_snapshot_persistence.py
+++ b/tests/test_snapshot_persistence.py
@@ -99,8 +99,11 @@ def run_snapshot_persistence_test() -> None:
             baseline = pending_bets.get(key, {}).get("baseline_consensus_prob")
             if baseline is None:
                 baseline = snapshot_cache.get(key, {}).get(
-                    "baseline_consensus_prob", r["market_prob"]
+                    "baseline_consensus_prob"
                 )
+            if baseline is None:
+                # baseline_consensus_prob = original implied probability when bet first appeared; never overwritten
+                baseline = r.get("consensus_prob")
             r["baseline_consensus_prob"] = baseline
 
             prior = detect_movement_and_update(r)


### PR DESCRIPTION
## Summary
- remove market prob fallback in `update_pending_from_snapshot.py`
- update snapshot persistence test to use consensus-only fallback for baseline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2cda2048832cb03d6a2135fce9c7