### PR TITLE
Remove market_prob fallback from snapshot baseline

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -751,7 +751,7 @@ def compare_and_flag_new_rows(
         if baseline is None:
             baseline = (prior or {}).get("baseline_consensus_prob") or entry.get(
                 "consensus_prob"
-            ) or entry.get("market_prob")
+            )
         entry["baseline_consensus_prob"] = baseline
         movement = track_and_update_market_movement(
             entry,


### PR DESCRIPTION
## Summary
- stop using `market_prob` as a fallback when setting `baseline_consensus_prob`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3cd0f520832cb97f9eb088223c9f