### PR TITLE
Fix baseline consensus fallback

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1566,7 +1566,6 @@ def write_to_csv(
         row["baseline_consensus_prob"] = (
             (prior_snapshot or {}).get("baseline_consensus_prob")
             or row.get("consensus_prob")
-            or row.get("market_prob")
         )
 
     # baseline_consensus_prob = original implied probability when bet first appeared; never overwritten
@@ -1674,7 +1673,7 @@ def write_to_csv(
         )
         baseline = row.get("baseline_consensus_prob")
         if baseline is None:
-            baseline = prior_row.get("baseline_consensus_prob") or row.get("consensus_prob") or row.get("market_prob")
+            baseline = prior_row.get("baseline_consensus_prob") or row.get("consensus_prob")
         # baseline_consensus_prob = original implied probability when bet first appeared; never overwritten
         row["baseline_consensus_prob"] = baseline
         annotate_display_deltas(row, prior_row)


### PR DESCRIPTION
## Summary
- remove `market_prob` fallback when setting `baseline_consensus_prob`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c3f7e9138832cbd85153517089d26