### PR TITLE
Add overwrite warning for baseline consensus prob

### DIFF
--- a/core/market_movement_tracker.py
+++ b/core/market_movement_tracker.py
@@ -190,6 +190,16 @@ def track_and_update_market_movement(
     ):
         return movement
 
+    if (
+        prior.get("baseline_consensus_prob") is not None
+        and entry.get("baseline_consensus_prob")
+        != prior.get("baseline_consensus_prob")
+    ):
+        logger.warning(
+            "\u26a0\ufe0f Attempted overwrite of baseline_consensus_prob for %s",
+            key,
+        )
+
     tracker_entry = {
         "ev_percent": entry.get("ev_percent"),
         "blended_fv": entry.get("blended_fv"),


### PR DESCRIPTION
## Summary
- log attempts to overwrite baseline_consensus_prob in `track_and_update_market_movement`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c44186ff8832c950238426c5d0939