### PR TITLE
Ensure baseline consensus initialized before movement tracking

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1666,6 +1666,12 @@ def write_to_csv(
         # baseline_consensus_prob = original implied probability when bet first appeared; never overwritten
         row["baseline_consensus_prob"] = baseline
 
+        if row.get("baseline_consensus_prob") is None:
+            row["baseline_consensus_prob"] = (
+                (prior_row or {}).get("baseline_consensus_prob")
+                or row.get("consensus_prob")
+            )
+
         movement = track_and_update_market_movement(
             row,
             MARKET_EVAL_TRACKER,


### PR DESCRIPTION
## Summary
- fix baseline consensus tracking bug

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7249c428832c91756d40093829d7