### PR TITLE
Ensure tracker reconciles after snapshot

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -388,6 +388,9 @@ if initial_odds:
     else:
         run_unified_snapshot_and_dispatch(initial_odds)
 
+        # Reconcile tracker immediately after snapshot generation
+        run_subprocess([PYTHON, "-m", "scripts.reconcile_tracker_with_csv"])
+
 start_time = time.time()
 loop_count = 0
 if not initial_odds:
@@ -445,6 +448,9 @@ while True:
                 run_subprocess([PYTHON, "-m", "scripts.reconcile_theme_exposure"])
                 run_subprocess([PYTHON, "-m", "scripts.reconcile_tracker_with_csv"])
                 run_unified_snapshot_and_dispatch(odds_file)
+
+                # Reconcile tracker immediately after snapshot generation
+                run_subprocess([PYTHON, "-m", "scripts.reconcile_tracker_with_csv"])
 
                 # Snapshot-first model: no pending_bets.json to update
 


### PR DESCRIPTION
## Summary
- update `auto_sim_and_log_loop` so tracker reconciliation runs immediately after snapshot generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c83288fa0832ca1b543acd138c541