### PR TITLE
Preserve market_eval_tracker across log loop

### DIFF
--- a/cli/auto_sim_and_log_loop.py
+++ b/cli/auto_sim_and_log_loop.py
@@ -380,7 +380,7 @@ if initial_odds:
     run_logger(initial_odds)
     logger.info("🧼 [%s] Reconciling tracker after log pass", now_eastern())
     run_subprocess([PYTHON, "-m", "scripts.reconcile_theme_exposure"])
-    run_subprocess([PYTHON, "-m", "scripts.reconcile_tracker_with_csv"])
+    # ⚠️ Do not reconcile market_eval_tracker — this file preserves baseline + market memory
     if any(p["name"].startswith("dispatch_") for p in active_processes):
         logger.info(
             "🟡 Skipping snapshot dispatch – previous dispatch scripts still active."
@@ -388,8 +388,7 @@ if initial_odds:
     else:
         run_unified_snapshot_and_dispatch(initial_odds)
 
-        # Reconcile tracker immediately after snapshot generation
-        run_subprocess([PYTHON, "-m", "scripts.reconcile_tracker_with_csv"])
+        # ⚠️ Do not reconcile market_eval_tracker — this file preserves baseline + market memory
 
 start_time = time.time()
 loop_count = 0
@@ -446,11 +445,10 @@ while True:
                     "🧼 [%s] Reconciling tracker after log pass", now_eastern()
                 )
                 run_subprocess([PYTHON, "-m", "scripts.reconcile_theme_exposure"])
-                run_subprocess([PYTHON, "-m", "scripts.reconcile_tracker_with_csv"])
+                # ⚠️ Do not reconcile market_eval_tracker — this file preserves baseline + market memory
                 run_unified_snapshot_and_dispatch(odds_file)
 
-                # Reconcile tracker immediately after snapshot generation
-                run_subprocess([PYTHON, "-m", "scripts.reconcile_tracker_with_csv"])
+                # ⚠️ Do not reconcile market_eval_tracker — this file preserves baseline + market memory
 
                 # Snapshot-first model: no pending_bets.json to update
 


### PR DESCRIPTION
## Summary
- stop calling `reconcile_tracker_with_csv` inside `auto_sim_and_log_loop`
- add warnings explaining why we no longer reconcile the tracker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c88331f44832c935e5fcca29a71ea