### PR TITLE
Switch trackers to snapshot storage

### DIFF
--- a/core/market_snapshot_tracker.py
+++ b/core/market_snapshot_tracker.py
@@ -1,0 +1,41 @@
+import os
+import json
+from datetime import datetime
+from typing import Dict, Tuple
+
+from core.utils import safe_load_json
+from core.lock_utils import with_locked_file
+from core.market_eval_tracker import build_tracker_key
+from core.snapshot_tracker_loader import find_latest_market_snapshot_path
+
+DEFAULT_DIR = "backtest"
+
+
+def load_latest_snapshot_tracker(directory: str = DEFAULT_DIR) -> Tuple[Dict[str, dict], str | None]:
+    """Return tracker dict built from the most recent snapshot file."""
+    path = find_latest_market_snapshot_path(directory)
+    if not path or not os.path.exists(path):
+        return {}, None
+
+    data = safe_load_json(path) or []
+    tracker: Dict[str, dict] = {}
+    rows = data if isinstance(data, list) else data.values() if isinstance(data, dict) else []
+    for row in rows:
+        key = build_tracker_key(row.get("game_id"), row.get("market"), row.get("side"))
+        tracker[key] = row
+    return tracker, path
+
+
+def write_market_snapshot(tracker: Dict[str, dict], directory: str = DEFAULT_DIR) -> str:
+    """Persist ``tracker`` as a new ``market_snapshot_*.json`` file."""
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+    path = os.path.join(directory, f"market_snapshot_{timestamp}.json")
+    tmp = path + ".tmp"
+    lock = path + ".lock"
+    os.makedirs(directory, exist_ok=True)
+    rows = list(tracker.values())
+    with with_locked_file(lock):
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(rows, f, indent=2)
+        os.replace(tmp, path)
+    return path

--- a/scripts/monitor_early_bets.py
+++ b/scripts/monitor_early_bets.py
@@ -14,7 +14,7 @@ from cli.log_betting_evals import (
     build_theme_exposure_tracker,
 )
 from core.shared_logging_logic import evaluate_snapshot_row_for_logging
-from core.market_eval_tracker import load_tracker as load_eval_tracker
+from core.market_snapshot_tracker import load_latest_snapshot_tracker
 
 logger = get_logger(__name__)
 
@@ -53,7 +53,7 @@ def recheck_pending_bets(backtest_dir: str = DEFAULT_BACKTEST_DIR) -> None:
     existing = load_existing_stakes("logs/market_evals.csv")
     session_exposure = defaultdict(set)
     theme_stakes = build_theme_exposure_tracker("logs/market_evals.csv")
-    eval_tracker = load_eval_tracker()
+    eval_tracker, _ = load_latest_snapshot_tracker()
 
     updated_rows = []
     changed = False


### PR DESCRIPTION
## Summary
- build `core.market_snapshot_tracker` to load the most recent snapshot and write updates
- use the snapshot tracker in `log_betting_evals.py`
- update monitor script to load snapshot tracker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d12aff3b0832c943a3903ca6fd1d4