### PR TITLE
Fix baseline consensus assignment

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -117,8 +117,8 @@ def build_snapshot_rows(sim_data: dict, odds_json: dict, min_ev: float = 0.01):
 def _enrich_snapshot_row(row: dict, *, debug_movement: bool = False) -> None:
     """Populate enrichment fields on a snapshot row."""
     # 🧩 Enrich: baseline
-    if row.get("baseline_consensus_prob") is None:
-        row["baseline_consensus_prob"] = row.get("consensus_prob")
+    if row.get("baseline_consensus_prob") is None and row.get("consensus_prob") is not None:
+        row["baseline_consensus_prob"] = row["consensus_prob"]
     baseline = row.get("baseline_consensus_prob")
 
     curr = row.get("market_prob") or row.get("consensus_prob")


### PR DESCRIPTION
## Summary
- guard baseline consensus assignment on consensus prob presence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1f43ea98832c841b53478636ec7f