### PR TITLE
Remove redundant baseline consensus assignment

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1478,11 +1478,6 @@ def expand_snapshot_rows_with_kelly(
         if not isinstance(per_book, dict) or not per_book:
             if row.get("market_odds") is None:
                 row["skip_reason"] = "no_odds"
-            if row.get("baseline_consensus_prob") is None:
-                row["baseline_consensus_prob"] = (
-                    (prior_row or {}).get("baseline_consensus_prob")
-                    or row.get("consensus_prob")
-                )
             movement = track_and_update_market_movement(
                 row,
                 MARKET_EVAL_TRACKER,


### PR DESCRIPTION
## Summary
- remove outdated fallback that reassigned `baseline_consensus_prob`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3003d31c832c830a41bb0df2be41