### PR TITLE
Fix snapshot rename overwrite

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -573,6 +573,8 @@ def main() -> None:
             return
 
         try:
+            if os.path.exists(final_path):
+                os.remove(final_path)  # 🔐 Ensure overwrite is possible
             os.rename(tmp_path, final_path)
         except Exception:
             logger.exception(


### PR DESCRIPTION
## Summary
- ensure existing snapshot files can be overwritten when renaming

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3920c2d0832cbe625ed54f770e80