### PR TITLE
Fix baseline fallback for per-book snapshot rows

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1581,9 +1581,7 @@ def expand_snapshot_rows_with_kelly(
             # --- Ensure baseline_consensus_prob is included ---
             tracker = MARKET_EVAL_TRACKER_BEFORE_UPDATE
             key = tracker_key
-            baseline = expanded_row.get("baseline_consensus_prob")
-            if baseline is None:
-                baseline = (prior_row or {}).get("baseline_consensus_prob")
+            baseline = (prior_row or {}).get("baseline_consensus_prob")
             if baseline is None:
                 baseline = tracker.get(key, {}).get("baseline_consensus_prob")
             if baseline is None:


### PR DESCRIPTION
## Summary
- ensure `baseline_consensus_prob` is inherited for each expanded sportsbook row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d441380b4832cb03b6c4a7942dbef