### PR TITLE
Add snapshot summary CSV export

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -23,6 +23,7 @@ from core.config import DEBUG_MODE, VERBOSE_MODE
 import json
 import argparse
 import shutil
+import csv
 from datetime import timedelta
 from core.bootstrap import *  # noqa
 
@@ -585,6 +586,75 @@ def main() -> None:
             return
 
         logger.info("✅ Snapshot written: %s with %d rows", final_path, len(all_rows))
+
+        # -------------------------------------------------------------------
+        # Write summary CSV for log-ready bets
+        # -------------------------------------------------------------------
+        summary_path = os.path.join(out_dir, f"snapshot_summary_{timestamp}.csv")
+        headers = [
+            "game_id",
+            "market",
+            "side",
+            "ev_percent",
+            "raw_kelly",
+            "stake",
+            "baseline_consensus_prob",
+            "market_prob",
+            "best_book",
+            "market_odds",
+            "consensus_move",
+            "required_move",
+            "movement_confirmed",
+            "should_be_logged",
+        ]
+
+        with open(summary_path, "w", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=headers)
+            writer.writeheader()
+
+            for row in all_rows:
+                try:
+                    ev = float(row.get("ev_percent", 0))
+                    stake = float(row.get("stake", row.get("full_stake", 0) or 0))
+                    if ev < 5.0 or stake < 1.0:
+                        continue
+
+                    baseline = row.get("baseline_consensus_prob")
+                    market_prob = row.get("market_prob")
+                    best_book = row.get("best_book")
+                    market_odds = row.get("market_odds")
+                    required_move = row.get("required_move")
+                    movement_confirmed = bool(row.get("movement_confirmed"))
+
+                    if None in (baseline, market_prob, best_book, market_odds, required_move):
+                        continue
+
+                    consensus_move = float(baseline) - float(market_prob)
+                    should_be_logged = (
+                        "Yes" if movement_confirmed and ev >= 5.0 and stake >= 1.0 else "No"
+                    )
+
+                    writer.writerow(
+                        {
+                            "game_id": row.get("game_id"),
+                            "market": row.get("market"),
+                            "side": row.get("side"),
+                            "ev_percent": f"{ev:.4f}",
+                            "raw_kelly": f"{float(row.get('raw_kelly', 0) or 0):.4f}",
+                            "stake": f"{stake:.4f}",
+                            "baseline_consensus_prob": f"{float(baseline):.4f}",
+                            "market_prob": f"{float(market_prob):.4f}",
+                            "best_book": best_book,
+                            "market_odds": market_odds,
+                            "consensus_move": f"{consensus_move:.4f}",
+                            "required_move": f"{float(required_move):.4f}",
+                            "movement_confirmed": movement_confirmed,
+                            "should_be_logged": should_be_logged,
+                        }
+                    )
+                except Exception:
+                    # Skip rows with invalid or missing data
+                    continue
     except Exception:
         logger.exception("Snapshot generation failed:")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- export a log-ready summary CSV after snapshot JSON is finalized

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4595d750832c816a8b91f4d33109