### PR TITLE
Fix baseline consensus persistence logic

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -769,11 +769,13 @@ def compare_and_flag_new_rows(
                 "prev_blended_fv": (prior or {}).get("blended_fv"),
             }
         )
-        baseline = entry.get("baseline_consensus_prob")
+        tracker = MARKET_EVAL_TRACKER_BEFORE_UPDATE
+        baseline = (prior or {}).get("baseline_consensus_prob")
         if baseline is None:
-            baseline = (prior or {}).get("baseline_consensus_prob") or entry.get(
-                "consensus_prob"
-            )
+            baseline = tracker.get(key, {}).get("baseline_consensus_prob")
+        if baseline is None:
+            baseline = entry.get("consensus_prob")
+
         entry["baseline_consensus_prob"] = baseline
         movement = track_and_update_market_movement(
             entry,
@@ -1467,9 +1469,7 @@ def expand_snapshot_rows_with_kelly(
         # --- Ensure baseline_consensus_prob is included ---
         tracker = MARKET_EVAL_TRACKER_BEFORE_UPDATE
         key = tracker_key
-        baseline = row.get("baseline_consensus_prob")
-        if baseline is None:
-            baseline = (prior_row or {}).get("baseline_consensus_prob")
+        baseline = (prior_row or {}).get("baseline_consensus_prob")
         if baseline is None:
             baseline = tracker.get(key, {}).get("baseline_consensus_prob")
         if baseline is None:

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -284,8 +284,9 @@ def _merge_persistent_fields(rows: list, prior_map: dict) -> None:
             continue
         for field in fields:
             if field == "baseline_consensus_prob":
-                if row.get(field) is None and prior.get(field) is not None:
-                    row[field] = prior[field]
+                prior_val = prior.get(field)
+                if prior_val is not None and row.get(field) is None:
+                    row[field] = prior_val
             elif field == "snapshot_roles":
                 prior_roles = prior.get(field)
                 if prior_roles:


### PR DESCRIPTION
## Summary
- prevent overwriting `baseline_consensus_prob` with `None`
- use tracker fallback when computing baseline in snapshot logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d4c017714832ca145b82c16b1fdf8