### PR TITLE
Fix consensus_move sign

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -1525,7 +1525,7 @@ def write_to_csv(
     if DEBUG and "baseline_consensus_prob" in row and "market_prob" in row:
         base = row.get("baseline_consensus_prob")
         current = row.get("market_prob")
-        delta = round(current - base, 4) if base is not None and current is not None else "?"
+        delta = round(base - current, 4) if base is not None and current is not None else "?"
         print(
             f"[confirmation_debug] {row['game_id']} | {row['market']} | {row['side']} — baseline: {base}, current: {current}, delta: {delta}"
         )

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -214,7 +214,7 @@ def _enrich_snapshot_row(row: dict, *, debug_movement: bool = False) -> None:
     try:
         curr_prob = float(row.get("market_prob"))
         base_prob = float(row.get("baseline_consensus_prob"))
-        row["consensus_move"] = round(curr_prob - base_prob, 5)
+        row["consensus_move"] = round(base_prob - curr_prob, 5)
     except Exception:
         row["consensus_move"] = 0.0
 
@@ -241,7 +241,7 @@ def _enrich_snapshot_row(row: dict, *, debug_movement: bool = False) -> None:
     if debug_movement:
         global _movement_debug_count
         if _movement_debug_count < MOVEMENT_DEBUG_LIMIT:
-            delta = (row.get("market_prob") or 0) - (row.get("baseline_consensus_prob") or 0)
+            delta = (row.get("baseline_consensus_prob") or 0) - (row.get("market_prob") or 0)
             print(
                 f"Movement Debug → game_id: {row.get('game_id')} | Baseline: {row.get('baseline_consensus_prob')}"
                 f" | Market: {row.get('market_prob')} | Δ = {delta*100:+.1f}% | confirmed: {row.get('movement_confirmed')}"


### PR DESCRIPTION
## Summary
- correct consensus_move logic to compute baseline minus market probability
- tweak debug delta print in betting eval logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e83f72e78832c8ac5bcad9ba21006