### PR TITLE
Adjust fallback odds lookup tolerance

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1072,7 +1072,7 @@ def lookup_fallback_odds(
     game_id: str,
     fallback_odds: dict,
     *,
-    max_delta: int | None = 3,
+    max_delta: int | None = 10,
     debug: bool = False,
 ) -> tuple[dict | None, str | None]:
     """Return the best-matching fallback odds entry for ``game_id``.
@@ -1160,9 +1160,22 @@ def lookup_fallback_odds(
     best_delta, best_key = scored[0]
 
     if max_delta is not None and best_delta is not None and best_delta > max_delta:
-        if debug:
-            print(f"[Fallback Debug] Tried fuzzy match for {game_id} — no similar keys found.")
-        return None, None
+        if len(candidates) == 1:
+            from core.logger import get_logger
+            logger = get_logger(__name__)
+            logger.warning(
+                "⚠️ Fallback odds delta %s exceeds max %s for %s; using %s because it was the only match",
+                best_delta,
+                max_delta,
+                game_id,
+                best_key,
+            )
+        else:
+            if debug:
+                print(
+                    f"[Fallback Debug] Tried fuzzy match for {game_id} — no similar keys found."
+                )
+            return None, None
 
     row = fallback_odds.get(best_key)
     if row and debug:

--- a/tests/test_lookup_fallback_odds.py
+++ b/tests/test_lookup_fallback_odds.py
@@ -46,3 +46,15 @@ def test_lookup_fallback_odds_fuzzy_off_by_one():
     }
     result, key = lookup_fallback_odds("2025-07-07-TOR@CWS-T1940", odds)
     assert result == {"val": 1}
+    assert key == "2025-07-07-TOR@CWS-T1941"
+
+
+def test_lookup_fallback_odds_unique_exceeds_delta(caplog):
+    odds = {
+        "2025-07-07-TOR@CWS-T2200": {"val": 99},
+    }
+    with caplog.at_level(logging.WARNING):
+        row, key = lookup_fallback_odds("2025-07-07-TOR@CWS-T2140", odds)
+    assert row == {"val": 99}
+    assert key == "2025-07-07-TOR@CWS-T2200"
+    assert any("only match" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- allow 10‑minute delta in `lookup_fallback_odds` and warn when exceeding it if only one odds entry matches
- expect the warning in new test case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e9cc5c2c4832c82b2825bc579db2d