### PR TITLE
Use dynamic required_move for should_log_bet

### DIFF
--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -350,7 +350,8 @@ def should_log_bet(
     if "market_prob" not in new_bet and "consensus_prob" in new_bet:
         new_bet["market_prob"] = new_bet["consensus_prob"]
     new_prob = new_bet.get("market_prob")
-    threshold = market_prob_increase_threshold
+    # Allow snapshot-defined thresholds to override the static constant
+    threshold = required_move if required_move > 0 else market_prob_increase_threshold
 
     if entry_type in {"first", "top-up"}:
         if baseline_prob is None or new_prob is None:

--- a/tests/test_should_log_bet.py
+++ b/tests/test_should_log_bet.py
@@ -1,0 +1,36 @@
+import pytest
+
+from core.should_log_bet import should_log_bet
+from core.skip_reasons import SkipReason
+
+
+def _base_bet(required_move):
+    return {
+        "game_id": "GAME1",
+        "market": "totals",
+        "side": "Over 8.5",
+        "baseline_consensus_prob": 0.50,
+        "market_prob": 0.518,
+        "consensus_move": 0.018,
+        "required_move": required_move,
+        "ev_percent": 6.0,
+        "raw_kelly": 1.0,
+        "hours_to_game": 3,
+        "market_odds": -110,
+        "best_book": "fanduel",
+        "_raw_sportsbook": {"fanduel": -110},
+    }
+
+
+def test_required_move_overrides_default():
+    bet = _base_bet(0.02)
+    result = should_log_bet(bet.copy(), {}, existing_csv_stakes={})
+    assert result["skip"] is True
+    assert result["reason"] == SkipReason.MARKET_NOT_MOVED.value
+
+
+def test_log_when_move_exceeds_required():
+    bet = _base_bet(0.015)
+    result = should_log_bet(bet.copy(), {}, existing_csv_stakes={})
+    assert result["log"] is True
+    assert result["entry_type"] == "first"


### PR DESCRIPTION
## Summary
- respect dynamic `required_move` threshold in `should_log_bet`
- add regression tests for movement threshold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed05b1c44832c99a5df176c4295ed