### PR TITLE
Refactor segment handling for full-game bets

### DIFF
--- a/core/theme_exposure_tracker.py
+++ b/core/theme_exposure_tracker.py
@@ -32,16 +32,18 @@ def load_tracker(path: str = TRACKER_PATH) -> Dict[str, float]:
         stakes: Dict[str, float] = {}
         for k, v in data.items():
             if isinstance(k, str):
-                if "::" in k and k.count("::") == 2:
-                    stakes[k] = float(v)
+                if "::" in k:
+                    gid, theme, seg = parse_theme_key(k)
+                    norm_key = make_theme_key(gid, theme, seg)
+                    stakes[norm_key] = float(v)
                     continue
                 try:
                     key = ast.literal_eval(k)
                 except Exception:
                     key = None
                 if isinstance(key, (list, tuple)) and len(key) == 3:
-                    stakes[make_theme_key(str(key[0]), str(key[1]), str(key[2]))] = (
-                        float(v)
+                    stakes[make_theme_key(str(key[0]), str(key[1]), str(key[2]))] = float(
+                        v
                     )
         return stakes
     except Exception:

--- a/core/theme_key_utils.py
+++ b/core/theme_key_utils.py
@@ -2,15 +2,40 @@
 
 from typing import Tuple
 
+from core.logger import get_logger
 
-def make_theme_key(game_id: str, theme: str, segment: str) -> str:
-    """Return a canonical theme key string."""
-    return f"{game_id}::{theme}::{segment}"
+
+def make_theme_key(game_id: str, theme: str, segment: str | None = "") -> str:
+    """Return a canonical theme key string.
+
+    ``segment`` is optional. When empty or ``"full_game"``, the key omits the
+    trailing segment portion.
+    """
+    seg = segment or ""
+    if seg == "full_game":
+        logger = get_logger(__name__)
+        logger.warning("make_theme_key received 'full_game' segment")
+        seg = ""
+
+    return f"{game_id}::{theme}" if not seg else f"{game_id}::{theme}::{seg}"
 
 
 def parse_theme_key(key: str) -> Tuple[str, str, str]:
     """Parse a theme key string into its components."""
-    return tuple(key.split("::", 2))  # type: ignore[return-value]
+    parts = key.split("::", 2)
+    if len(parts) == 2:
+        game_id, theme = parts
+        segment = ""
+    elif len(parts) >= 3:
+        game_id, theme, segment = parts[0], parts[1], parts[2]
+    else:
+        # malformed key
+        parts += ["", "", ""]
+        game_id, theme, segment = parts[:3]
+
+    if segment == "full_game":
+        segment = ""
+    return game_id, theme, segment
 
 
 def theme_key_equals(a: str, b: str) -> bool:

--- a/core/theme_utils.py
+++ b/core/theme_utils.py
@@ -76,7 +76,7 @@ def get_theme_key(market: str, theme: str) -> str:
 
 def normalize_segment(market: str) -> str:
     """Return a unified segment tag from a raw market name."""
-    m = market.lower()
+    m = str(market).lower()
     if "1st_3" in m:
         return "1st_3"
     if "1st_5" in m:
@@ -85,5 +85,12 @@ def normalize_segment(market: str) -> str:
         return "1st_7"
     if "1st_1" in m or "1st_inning" in m:
         return "1st"
-    return "full_game"
+
+    # Full-game bets should not carry an explicit segment key
+    if "full_game" in m:
+        from core.logger import get_logger
+
+        logger = get_logger(__name__)
+        logger.warning("normalize_segment received literal 'full_game'")
+    return ""
 


### PR DESCRIPTION
## Summary
- normalize_segment returns an empty string for full-game bets
- generate theme keys without a segment when full-game
- normalize existing tracker keys on load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1319d094832c8a4bf6c7236ff1bf