### PR TITLE
Preserve consensus books_used

### DIFF
--- a/core/odds_fetcher.py
+++ b/core/odds_fetcher.py
@@ -489,6 +489,8 @@ def fetch_market_odds_from_api(game_ids, filter_bookmakers=None, lookahead_days=
                         label=label,
                     )
                     normalized[mkt_key][label].update(result)
+                    if "books_used" in result:
+                        normalized[mkt_key][label]["books_used"] = result["books_used"]
 
             # Ensure all expected market keys exist for downstream tools
             for key in MARKET_KEYS:
@@ -697,6 +699,8 @@ def fetch_all_market_odds(lookahead_days=2):
                         label=label,
                     )
                     normalized[mkt_key][label].update(result)
+                    if "books_used" in result:
+                        normalized[mkt_key][label]["books_used"] = result["books_used"]
 
             for key in MARKET_KEYS:
                 normalized.setdefault(key, {})


### PR DESCRIPTION
## Summary
- ensure books_used from `calculate_consensus_prob` is stored in both fetch loops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f27c4673c832c96117c619f726591