### PR TITLE
Add snapshot required_move test

### DIFF
--- a/tests/data/sample_snapshot_row.json
+++ b/tests/data/sample_snapshot_row.json
@@ -1,0 +1,9 @@
+{
+  "game_id": "TEST-GAME",
+  "market": "totals",
+  "side": "Over 8.5",
+  "hours_to_game": 6.0,
+  "ev_percent": 8.0,
+  "books_used": ["fanduel", "draftkings", "betmgm", "betonlineag"],
+  "required_move": 0.00225
+}

--- a/tests/test_snapshot_required_move.py
+++ b/tests/test_snapshot_required_move.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from core.confirmation_utils import required_market_move, extract_book_count
+
+
+def test_snapshot_required_move_alignment():
+    path = Path(__file__).parent / "data" / "sample_snapshot_row.json"
+    row = json.loads(path.read_text())
+
+    recomputed = required_market_move(
+        hours_to_game=row["hours_to_game"],
+        book_count=extract_book_count(row),
+        market=row.get("market"),
+        ev_percent=row.get("ev_percent"),
+    )
+
+    assert round(row["required_move"], 5) == round(recomputed, 5)


### PR DESCRIPTION
## Summary
- add sample snapshot row fixture
- ensure required_move reflects number of books used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f8d6a73dc832cb08721f441e62c91