### PR TITLE
Propagate books_used into snapshot rows

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1017,7 +1017,9 @@ def build_snapshot_rows(
             book_odds_list = list(result.get("bookwise_probs", {}).values())
 
             # Capture which sportsbooks formed the consensus line
-            books_used = market_entry.get("books_used", [])
+            books_used = result.get("books_used")
+            if books_used is None:
+                books_used = market_entry.get("books_used", [])
 
             market_clean = matched_key.replace("alternate_", "")
             market_class = "alternate" if price_source == "alternate" else "main"


### PR DESCRIPTION
## Summary
- grab books_used from consensus_pricer if provided
- keep fallback to books_used in the market entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fa4c2731c832c901617d57b786c7a