### PR TITLE
Allow Alt market lines in FV drop dispatch

### DIFF
--- a/core/dispatch_fv_drop_snapshot.py
+++ b/core/dispatch_fv_drop_snapshot.py
@@ -354,7 +354,8 @@ def main() -> None:
             df = df[inc_mask]
 
     # Prepare DataFrame copies for sending to the different Discord channels
-    df_main = filter_main_lines(df.copy())
+    # Include both Main and Alt market classes in the dispatch
+    df_main = df.copy()
     df_main = filter_by_odds(
         df_main,
         MIN_NEGATIVE_ODDS,


### PR DESCRIPTION
## Summary
- include Alt lines when sending FV drop snapshots to Discord

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc632ca4c832c99d8007f61bf986c