### PR TITLE
Implement snapshot load filtering

### DIFF
--- a/core/dispatch_best_book_snapshot.py
+++ b/core/dispatch_best_book_snapshot.py
@@ -30,11 +30,27 @@ def load_latest_snapshot_rows() -> list:
     path = find_latest_market_snapshot_path("backtest")
     rows = safe_load_json(path) if path else []
     logger.info("📊 Loaded %d snapshot rows from %s", len(rows), path)
+    filtered = []
     for r in rows:
         ensure_side(r)
         if "market_class" not in r:
             r["market_class"] = "main"
-    return rows
+
+        try:
+            stake = float(r.get("stake", r.get("raw_kelly", 0)) or 0)
+        except Exception:
+            stake = 0.0
+        try:
+            ev = float(r.get("ev_percent", 0) or 0)
+        except Exception:
+            ev = 0.0
+
+        if stake < 1.0 and ev < 5.0 and not r.get("snapshot_roles"):
+            continue
+
+        filtered.append(r)
+
+    return filtered
 
 
 def filter_by_date(rows: list, date_str: str | None) -> list:

--- a/core/dispatch_live_snapshot.py
+++ b/core/dispatch_live_snapshot.py
@@ -30,9 +30,25 @@ def load_latest_snapshot_rows() -> list:
     path = find_latest_market_snapshot_path("backtest")
     rows = safe_load_json(path) if path else []
     logger.info("📊 Loaded %d snapshot rows from %s", len(rows), path)
+    filtered = []
     for r in rows:
         ensure_side(r)
-    return rows
+
+        try:
+            stake = float(r.get("stake", r.get("raw_kelly", 0)) or 0)
+        except Exception:
+            stake = 0.0
+        try:
+            ev = float(r.get("ev_percent", 0) or 0)
+        except Exception:
+            ev = 0.0
+
+        if stake < 1.0 and ev < 5.0 and not r.get("snapshot_roles"):
+            continue
+
+        filtered.append(r)
+
+    return filtered
 
 
 def filter_by_date(rows: list, date_str: str | None) -> list:

--- a/core/dispatch_personal_snapshot.py
+++ b/core/dispatch_personal_snapshot.py
@@ -37,9 +37,25 @@ def load_latest_snapshot_rows() -> list:
     path = find_latest_market_snapshot_path("backtest")
     rows = safe_load_json(path) if path else []
     logger.info("📊 Loaded %d snapshot rows from %s", len(rows), path)
+    filtered = []
     for r in rows:
         ensure_side(r)
-    return rows
+
+        try:
+            stake = float(r.get("stake", r.get("raw_kelly", 0)) or 0)
+        except Exception:
+            stake = 0.0
+        try:
+            ev = float(r.get("ev_percent", 0) or 0)
+        except Exception:
+            ev = 0.0
+
+        if stake < 1.0 and ev < 5.0 and not r.get("snapshot_roles"):
+            continue
+
+        filtered.append(r)
+
+    return filtered
 
 
 def filter_by_date(rows: list, date_str: str | None) -> list:

--- a/core/dispatch_sim_only_snapshot.py
+++ b/core/dispatch_sim_only_snapshot.py
@@ -54,9 +54,25 @@ def load_rows(path: str) -> List[dict]:
     if rows is None:
         logger.error("❌ Failed to load snapshot %s", path)
         sys.exit(1)
+    filtered: List[dict] = []
     for r in rows:
         ensure_side(r)
-    return rows
+
+        try:
+            stake = float(r.get("stake", r.get("raw_kelly", 0)) or 0)
+        except Exception:
+            stake = 0.0
+        try:
+            ev = float(r.get("ev_percent", 0) or 0)
+        except Exception:
+            ev = 0.0
+
+        if stake < 1.0 and ev < 5.0 and not r.get("snapshot_roles"):
+            continue
+
+        filtered.append(r)
+
+    return filtered
 
 
 def filter_by_date(rows: List[dict], date_str: str | None) -> List[dict]:


### PR DESCRIPTION
## Summary
- filter out noise rows directly when loading snapshot data in dispatch scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687021307ce8832c9b28be6f344cdbaa