### PR TITLE
Fix fv_drop role logic

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -205,7 +205,7 @@ def _enrich_snapshot_row(row: dict, *, debug_movement: bool = False) -> None:
         ev = float(row.get("ev_percent", 0))
         stake = float(row.get("stake", 0))
         if (
-            (base_prob - market_prob) > 0
+            (market_prob - base_prob) > 0
             and ev >= 5.0
             and stake >= 1.0
             and "fv_drop" not in roles

--- a/tests/test_fv_drop_role.py
+++ b/tests/test_fv_drop_role.py
@@ -1,0 +1,21 @@
+import core.unified_snapshot_generator as usg
+
+
+def test_fv_drop_role_assignment():
+    row = {
+        "game_id": "GAME1",
+        "market": "totals",
+        "side": "Over 8.5",
+        "market_prob": 0.55,
+        "baseline_consensus_prob": 0.50,
+        "ev_percent": 6.0,
+        "stake": 1.0,
+        "hours_to_game": 5,
+        "market_odds": -110,
+        "blended_prob": 0.6,
+        "market_class": "main",
+        "book": "fanduel",
+    }
+    usg._enrich_snapshot_row(row)
+    assert "fv_drop" in row.get("snapshot_roles", [])
+


### PR DESCRIPTION
## Summary
- fix FV Drop condition when enriching snapshot rows
- add regression test covering FV Drop role assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687062b877f0832cab877eef2aaeb23f