### PR TITLE
Fix park lookup using parse_game_id

### DIFF
--- a/assets/env_builder.py
+++ b/assets/env_builder.py
@@ -1,5 +1,6 @@
 import json
 import requests
+from core.utils import parse_game_id
 
 def get_park_name(game_id):
     park_by_home_team = {
@@ -34,7 +35,8 @@ def get_park_name(game_id):
         "NYY": "Yankee Stadium"
     }
     try:
-        home_abbr = game_id.split('@')[1].upper()
+        parsed = parse_game_id(str(game_id))
+        home_abbr = parsed.get("home", "").upper()
         return park_by_home_team.get(home_abbr, "League Average")
     except Exception as e:
         print(f"[WARNING] Could not extract park from game_id '{game_id}': {e}")

--- a/tests/test_get_park_name.py
+++ b/tests/test_get_park_name.py
@@ -1,0 +1,7 @@
+from assets.env_builder import get_park_name
+
+
+def test_game_id_maps_to_park():
+    """Game ID should resolve to the correct park name."""
+    game_id = "2025-07-10-ARI@LAA-T1905"
+    assert get_park_name(game_id) == "Angel Stadium"


### PR DESCRIPTION
## Summary
- use `parse_game_id` when extracting the home team in `get_park_name`
- add a unit test ensuring the correct park is found for a timestamped game id

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707b4661b4832c938734398b635088