### PR TITLE
Improve wind handling logic

### DIFF
--- a/tests/test_weather_effects.py
+++ b/tests/test_weather_effects.py
@@ -1,0 +1,13 @@
+from assets.env_builder import get_weather_hr_mult, compute_weather_multipliers
+
+
+def test_weather_hr_mult_neutral_south():
+    profile = {"wind_direction": "s", "wind_speed": 20}
+    assert get_weather_hr_mult(profile) == 1.0
+
+
+def test_weather_multipliers_neutral_west():
+    profile = {"wind_direction": "w", "wind_speed": 15, "temperature": 70, "humidity": 50}
+    result = compute_weather_multipliers(profile)
+    assert result["adi_mult"] == 1.0
+


### PR DESCRIPTION
## Summary
- map compass wind directions to `in`, `out`, or `cross`
- treat unrecognized winds as neutral
- adjust angle multipliers using the mapped wind direction
- test neutral handling for `s` and `w` wind directions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707cc2142c832c9d3bfa449bf9fe15