### PR TITLE
Ensure snapshot tracker loaded safely

### DIFF
--- a/debug_should_log_bet.py
+++ b/debug_should_log_bet.py
@@ -1,5 +1,4 @@
 import os
-import json
 from typing import Optional
 
 from core.utils import safe_load_json, safe_load_dict, parse_game_id
@@ -41,9 +40,7 @@ def load_snapshot_row(path: str, game_id: str, market: str, side: str) -> Option
 def load_snapshot_tracker(game_date: str) -> dict:
     path = find_latest_snapshot_tracker_path(game_date)
     if path and os.path.exists(path):
-        tracker = safe_load_dict(path)
-        if isinstance(tracker, dict):
-            return tracker
+        return safe_load_dict(path)
     try:
         return load_tracker_from_core()
     except Exception:

--- a/verify_baseline_persistence.py
+++ b/verify_baseline_persistence.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Dict
 
 from core.snapshot_core import build_key
-from core.utils import parse_snapshot_timestamp
+from core.utils import parse_snapshot_timestamp, safe_load_dict
 from core.snapshot_tracker_loader import (
     find_latest_market_snapshot_path,
     find_latest_snapshot_tracker_path,
@@ -41,13 +41,10 @@ def main() -> None:
         snapshot_date if snapshot_date is not None else datetime.now().date()
     )
     print(f"\U0001F4C4 Using tracker snapshot: {tracker_path}")
-    tracker: Dict[str, Any] = load_json(tracker_path) or {}
+    tracker: Dict[str, Any] = safe_load_dict(tracker_path)
 
     if not isinstance(snapshot, list):
         print("\u274c Snapshot file is not a list")
-        return
-    if not isinstance(tracker, dict):
-        print("\u274c Tracker file is not a dict")
         return
 
     header = [


### PR DESCRIPTION
## Summary
- load snapshot trackers with `safe_load_dict`
- clean up redundant type checks

## Testing
- `python -m py_compile debug_should_log_bet.py verify_baseline_persistence.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68708337e5a8832c82381b7f1992c90d