### PR TITLE
Update snapshot key to include book

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -291,7 +291,12 @@ def _load_prior_snapshot_map(directory: str = "backtest") -> dict:
     mapping = {}
     for r in data:
         canon_gid = canonical_game_id(r.get("game_id", ""))
-        key = (canon_gid, r.get("market"), r.get("side"))
+        key = (
+            canon_gid,
+            r.get("market"),
+            r.get("side"),
+            r.get("book") or r.get("best_book"),
+        )
         mapping[key] = r
     return mapping
 
@@ -302,7 +307,12 @@ def _merge_persistent_fields(rows: list, prior_map: dict) -> None:
     now_ts = now_eastern().isoformat()
     for row in rows:
         canon_gid = canonical_game_id(row.get("game_id", ""))
-        key = (canon_gid, row.get("market"), row.get("side"))
+        key = (
+            canon_gid,
+            row.get("market"),
+            row.get("side"),
+            row.get("book") or row.get("best_book"),
+        )
         prior = prior_map.get(key)
 
         # Always update the heartbeat timestamp
@@ -473,8 +483,15 @@ def build_snapshot_for_date(
                     print(f"[Consensus] Using inherited value: {row['consensus_prob']}")
 
         canon_gid = canonical_game_id(row.get("game_id", ""))
-        snap_key = (canon_gid, row_market, row_label)
-        prior_baseline = prior_map.get(snap_key, {}).get("baseline_consensus_prob") if prior_map else None
+        snap_key = (
+            canon_gid,
+            row_market,
+            row_label,
+            row.get("book") or row.get("best_book"),
+        )
+        prior_baseline = (
+            prior_map.get(snap_key, {}).get("baseline_consensus_prob") if prior_map else None
+        )
 
         if prior_baseline is not None:
             row["baseline_consensus_prob"] = prior_baseline

--- a/tests/test_baseline_persistence_generator.py
+++ b/tests/test_baseline_persistence_generator.py
@@ -45,7 +45,14 @@ def test_baseline_persists_across_runs(monkeypatch):
     first = usg.build_snapshot_for_date(date, odds1, (0.0, 10.0), prior_map=prior_map)
     assert first and first[0]["baseline_consensus_prob"] == 0.45
 
-    prior_map = {(canon_id, first[0]["market"], first[0]["side"]): first[0]}
+    prior_map = {
+        (
+            canon_id,
+            first[0]["market"],
+            first[0]["side"],
+            first[0].get("book", first[0].get("best_book")),
+        ): first[0]
+    }
     odds2 = {canon_id: {"totals": {"Over 8.5": {"consensus_prob": 0.50}}}}
     second = usg.build_snapshot_for_date(date, odds2, (0.0, 10.0), prior_map=prior_map)
     assert second and second[0]["baseline_consensus_prob"] == 0.45


### PR DESCRIPTION
## Summary
- include book when loading prior snapshot rows
- merge persistent snapshot fields using (game, market, side, book)
- track baseline probability by book in generator
- fix baseline persistence tests for book-aware keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687085de39ac832c8046f851e8bd6718