### PR TITLE
Sanitize snapshot rows on output

### DIFF
--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -667,18 +667,9 @@ def main() -> None:
             logger.debug("🗒️ Deduplicated %d rows from final snapshot", dropped)
         all_rows = deduped_rows
 
-        all_rows = [sanitize_json_row(r) for r in all_rows]
-
         os.makedirs(out_dir, exist_ok=True)
         with open(tmp_path, "w", encoding="utf-8") as f:
-            f.write("[\n")
-            first = True
-            for row in all_rows:
-                if not first:
-                    f.write(",\n")
-                json.dump(row, f)
-                first = False
-            f.write("\n]")
+            json.dump([sanitize_json_row(r) for r in all_rows], f, indent=2)
 
         # Validate written JSON before renaming
         try:


### PR DESCRIPTION
## Summary
- clean up final JSON writing in `unified_snapshot_generator`
- ensure rows are sanitized right before dumping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870ef40929c832cbd0251596edf06d1