### PR TITLE
Fix market_prob rounding discrepancy

### DIFF
--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -1079,7 +1079,7 @@ def build_snapshot_rows(
                 "market": market_clean,
                 "side": normalized_side,
                 "sim_prob": round(sim_prob, 4),
-                "market_prob": round(p_market, 4),
+                "market_prob": round(p_market, 6),
                 "blended_prob": round(p_blended, 4),
                 "blended_fv": 1 / p_blended,
                 "market_odds": price,


### PR DESCRIPTION
## Summary
- use 6 decimal precision for `market_prob` when creating snapshot rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687100ca10d8832cb6bd7510cf84900a