### PR TITLE
Replace full_stake with raw_kelly

### DIFF
--- a/cli/log_betting_evals.py
+++ b/cli/log_betting_evals.py
@@ -826,7 +826,6 @@ def expand_snapshot_rows_with_kelly(
                         "segment_label": bet.get("segment_label"),
                         "ev_percent": round(ev, 2),
                         "stake": stake,
-                        "full_stake": stake,
                         "raw_kelly": raw_kelly,
                         "_prior_snapshot": prior_snapshot_row,
                         "_raw_sportsbook": raw_books,
@@ -1069,7 +1068,7 @@ def get_market_class_emoji(segment_label: str) -> str:
 def get_topup_note(
     ev: float,
     stake: float,
-    full_stake: float,
+    raw_kelly: float,
     entry_type: str,
     market_class: str | None,
 ) -> tuple[str, str, str, str]:
@@ -1091,7 +1090,7 @@ def get_topup_note(
 
     note = ""
     if entry_type == "top-up":
-        note = f"\U0001f501 Top-Up: `{stake:.2f}u` added → Total: `{full_stake:.2f}u`"
+        note = f"\U0001f501 Top-Up: `{stake:.2f}u` added → Total: `{raw_kelly:.2f}u`"
 
     return tag, header, bet_label, note
 
@@ -1100,11 +1099,11 @@ def build_discord_embed(row: dict) -> str:
     """Return the Discord message body for a logged bet."""
     ev = float(row.get("ev_percent", 0))
     stake = round(float(row.get("stake", 0)), 2)
-    full_stake = round(float(row.get("full_stake", stake)), 2)
+    raw_kelly = round(float(row.get("raw_kelly", stake)), 2)
     entry_type = row.get("entry_type", "first")
 
     tag, header, bet_label, topup_note = get_topup_note(
-        ev, stake, full_stake, entry_type, row.get("market_class")
+        ev, stake, raw_kelly, entry_type, row.get("market_class")
     )
 
     if row.get("test_mode"):
@@ -1338,10 +1337,10 @@ def send_discord_notification(row, skipped_bets=None):
     print(f"Webhook URL resolved: {webhook_url}")
 
     stake = round(float(row.get("stake", 0)), 2)
-    full_stake = round(float(row.get("full_stake", stake)), 2)
+    raw_kelly = round(float(row.get("raw_kelly", stake)), 2)
     entry_type = row.get("entry_type", "first")
     print(
-        f"📬 Sending Discord Notification → stake: {stake}, full: {full_stake}, type: {entry_type}"
+        f"📬 Sending Discord Notification → stake: {stake}, full: {raw_kelly}, type: {entry_type}"
     )
 
     message = build_discord_embed(row)
@@ -1419,14 +1418,14 @@ def write_to_csv(
     #         f"  ⛔ Market confirmation not improved ({new_conf_val:.4f} ≤ {prev_conf_val:.4f}) — skipping {tracker_key}"
     #     )
     #     return 0
-    full_stake = round_stake(float(row.get("full_stake", 0)))
+    raw_kelly = round_stake(float(row.get("raw_kelly", 0)))
     entry_type = row.get("entry_type", "first")
-    stake_to_log = round_stake(row.get("stake", full_stake))
+    stake_to_log = round_stake(row.get("stake", raw_kelly))
 
     prev = existing.get(key, 0)
     row["cumulative_stake"] = prev + stake_to_log
-    # Preserve the total intended exposure in full_stake
-    row["full_stake"] = full_stake
+    # Preserve the total intended exposure in raw_kelly
+    row["raw_kelly"] = raw_kelly
     row["result"] = ""
 
     if dry_run:
@@ -1547,7 +1546,7 @@ def write_to_csv(
                 "_movement",
                 "_movement_str",
                 "_prior_snapshot",
-                "full_stake",
+                "raw_kelly",
                 "adjusted_kelly",
             ]:
                 row.pop(k, None)
@@ -1923,7 +1922,7 @@ def log_bets(
 
         # Continue with staking filters, logging, top-up checks...
 
-        row["full_stake"] = stake
+        row["raw_kelly"] = stake
 
         key = (game_id, matched_key, side)
         prev = existing.get(key, 0)
@@ -2321,7 +2320,7 @@ def log_derivative_bets(
                         except Exception:
                             pass
                 # Tracker update moved below evaluation to preserve prior state
-                row["full_stake"] = stake
+                row["raw_kelly"] = stake
                 row["price_source"] = price_source
                 row["segment"] = segment
 
@@ -2331,8 +2330,8 @@ def log_derivative_bets(
                     f"        → EV: {ev_calc:.2f}% | Stake: {stake:.2f}u | Model: {p_model:.1%} | Market: {p_market:.1%} | Odds: {market_price}"
                 )
 
-                full_stake = stake
-                row["full_stake"] = full_stake
+                raw_kelly_val = stake
+                row["raw_kelly"] = raw_kelly_val
                 row["entry_type"] = "top-up" if prev > 0 else "first"
                 row["result"] = ""
                 row.pop("consensus_books", None)
@@ -2395,7 +2394,7 @@ def send_summary_to_discord(skipped_bets, webhook_url):
                 "name": f"📅 {b['game_id']} | {b['market']} | {b['side']}",
                 "value": (
                     f"💸 Fair Odds: `{b['blended_fv']}`\n"
-                    f"💰 Stake: `{b.get('full_stake', b['stake']):.2f}u` @ `{b['market_odds']}`\n"
+                    f"💰 Stake: `{b.get('raw_kelly', b['stake']):.2f}u` @ `{b['market_odds']}`\n"
                     f"📈 EV: `{b['ev_percent']:+.2f}%`\n"
                     f"🚫 Reason: `{skip_reason}`\n"
                     f"🏦 Books:\n{books_str}"
@@ -2758,7 +2757,7 @@ def process_theme_logged_bets(
                 key=lambda x: 1 if x[1].get("market_class") == "alternate" else 0
             )
             for segment, row in ordered_rows:
-                stake = round(float(row.get("full_stake", row.get("stake", 0))), 2)
+                stake = round(float(row.get("raw_kelly", row.get("stake", 0))), 2)
                 ev = row.get("ev_percent", 0)
                 print(
                     f"   - {theme_key} [{segment}] → {row['side']} ({row['market']}) @ {stake:.2f}u | EV: {ev:.2f}%"
@@ -2780,8 +2779,8 @@ def process_theme_logged_bets(
                         delta_p = float(pending.get("delta", 0))
                     except Exception:
                         delta_p = 0.0
-                    row["full_stake"] = round(float(row.get("full_stake", 0)) + delta_p, 2)
-                proposed_stake = round(float(row.get("full_stake", 0)), 2)
+                    row["raw_kelly"] = round(float(row.get("raw_kelly", 0)) + delta_p, 2)
+                proposed_stake = round(float(row.get("raw_kelly", 0)), 2)
                 key = (row["game_id"], row["market"], row["side"])
                 line_key = (row["market"], row["side"])
                 theme_total = existing_exposure.get(exposure_key, 0.0)

--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -224,7 +224,7 @@ def evaluate_late_confirmed_bet(
         print(f"🔁 Using raw_kelly stake without confirmation scaling: {raw_kelly:.4f}")
         target_stake = round(raw_kelly, 4)
         try:
-            max_full = float(bet.get("full_stake", target_stake))
+            max_full = float(bet.get("raw_kelly", target_stake))
         except Exception:
             max_full = target_stake
         target_stake = min(target_stake, max_full)
@@ -232,7 +232,7 @@ def evaluate_late_confirmed_bet(
         updated.update(
             {
                 "stake": target_stake,
-                "full_stake": target_stake,
+                "raw_kelly": target_stake,
                 "entry_type": "first",
                 "consensus_prob": new_prob,
                 "market_prob": new_prob,
@@ -243,7 +243,7 @@ def evaluate_late_confirmed_bet(
     # Top-up: scale to raw Kelly ignoring confirmation
     target_stake = raw_kelly
     try:
-        max_full = float(bet.get("full_stake", target_stake))
+        max_full = float(bet.get("raw_kelly", target_stake))
     except Exception:
         max_full = target_stake
 
@@ -257,7 +257,7 @@ def evaluate_late_confirmed_bet(
     updated.update(
         {
             "stake": delta,
-            "full_stake": target_stake,
+            "raw_kelly": target_stake,
             "entry_type": "top-up",
             "consensus_prob": new_prob,
             "market_prob": new_prob,

--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -108,7 +108,7 @@ def build_skipped_evaluation(
     result = {
         "game_id": game_id,
         "log": False,
-        "full_stake": 0.0,
+        "raw_kelly": 0.0,
         "skip_reason": reason,
         "skip": True,
         "reason": reason,
@@ -215,13 +215,13 @@ def should_log_bet(
     market = new_bet["market"]
     side = normalize_label_for_odds(new_bet["side"], market)
     new_bet["side"] = side  # ensure consistent formatting
-    # ``full_stake`` may be absent in legacy entries; fall back to ``stake``
+    # ``raw_kelly`` may be absent in legacy entries; fall back to ``stake``
     # or 0.0 to avoid KeyError.
     stake = round_stake(
         float(
             new_bet.get(
                 "raw_kelly",
-                new_bet.get("full_stake", new_bet.get("stake", 0.0)),
+                new_bet.get("stake", 0.0),
             )
         )
     )
@@ -494,7 +494,7 @@ def should_log_bet(
             "skip",
             "log",
             "entry_type",
-            "full_stake",
+            "raw_kelly",
             "stake",
             "skip_reason",
         ]:
@@ -504,7 +504,7 @@ def should_log_bet(
             "log": True,
             "entry_type": "first",
             "stake": stake,
-            "full_stake": stake,
+            "raw_kelly": stake,
             "ev": ev,
             "game_id": game_id,
             "side": new_bet["side"],
@@ -521,7 +521,7 @@ def should_log_bet(
             "skip",
             "log",
             "entry_type",
-            "full_stake",
+            "raw_kelly",
             "stake",
             "skip_reason",
         ]:
@@ -531,7 +531,7 @@ def should_log_bet(
             "log": True,
             "entry_type": "top-up",
             "stake": rounded_delta,
-            "full_stake": stake,
+            "raw_kelly": stake,
             "partial_stake": rounded_delta,
             "ev": ev,
             "game_id": game_id,

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -509,8 +509,8 @@ def send_bet_snapshot_to_discord(
     try:
         min_stake = 1.0
         stake_vals = None
-        if "full_stake" in df.columns:
-            stake_vals = pd.to_numeric(df["full_stake"], errors="coerce")
+        if "raw_kelly" in df.columns:
+            stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
         elif "stake" in df.columns:
             stake_vals = pd.to_numeric(df["stake"], errors="coerce")
         elif "Stake" in df.columns:
@@ -605,7 +605,7 @@ def send_bet_snapshot_to_discord(
         "blended_fv",
         "market_class",
         "_raw_sportsbook",
-        "full_stake",
+        "raw_kelly",
         "blended_prob",
         "segment",
         "date_simulated",
@@ -1085,7 +1085,6 @@ def build_snapshot_rows(
                 "market_odds": price,
                 "ev_percent": round(ev_pct, 2),
                 "stake": stake,
-                "full_stake": stake,
                 "raw_kelly": raw_kelly,
                 "segment": segment,
                 "market_class": market_class,
@@ -1557,7 +1556,6 @@ def expand_snapshot_rows_with_kelly(
                     "market_odds": odds_val,
                     "ev_percent": round(ev, 2),
                     "stake": stake,
-                    "full_stake": stake,
                     "raw_kelly": raw_kelly,
                     "_raw_sportsbook": per_book,
                     "consensus_books": per_book,
@@ -1770,8 +1768,8 @@ def dispatch_snapshot_rows(
     # Stake filter (prospective bets bypass minimum)
     try:
         stake_vals = None
-        if "full_stake" in df.columns:
-            stake_vals = pd.to_numeric(df["full_stake"], errors="coerce")
+        if "raw_kelly" in df.columns:
+            stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
         elif "stake" in df.columns:
             stake_vals = pd.to_numeric(df["stake"], errors="coerce")
         elif "Stake" in df.columns:

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -270,7 +270,7 @@ def _enrich_snapshot_row(row: dict, *, debug_movement: bool = False) -> None:
     # 🧩 Enrich: early/low-EV gating
     ev = row.get("ev_percent", 0.0) or 0.0
     rk = row.get("raw_kelly", 0.0) or 0.0
-    stake = row.get("stake", row.get("full_stake", 0.0)) or 0.0
+    stake = row.get("stake", row.get("raw_kelly", 0.0)) or 0.0
     if ev < 5.0 and rk < 1.0 and stake < 1.0:
         row.setdefault("skip_reason", "low_ev")
 
@@ -346,7 +346,7 @@ def _merge_persistent_fields(rows: list, prior_map: dict) -> None:
             except Exception:
                 ev = 0.0
             try:
-                stake = float(row.get("stake", row.get("full_stake", 0) or 0))
+                stake = float(row.get("stake", row.get("raw_kelly", 0) or 0))
             except Exception:
                 stake = 0.0
 
@@ -761,7 +761,7 @@ def main() -> None:
                 for row in all_rows:
                     try:
                         ev = float(row.get("ev_percent", 0))
-                        stake = float(row.get("stake", row.get("full_stake", 0) or 0))
+                        stake = float(row.get("stake", row.get("raw_kelly", 0) or 0))
                         if ev < 5.0 or stake < 1.0:
                             continue
 
@@ -837,7 +837,7 @@ def main() -> None:
                             continue
 
                         ev = float(row.get("ev_percent", 0))
-                        stake = float(row.get("stake", row.get("full_stake", 0) or 0))
+                        stake = float(row.get("stake", row.get("raw_kelly", 0) or 0))
                         raw_kelly = float(row.get("raw_kelly", 0) or 0)
                         required_move = row.get("required_move")
                         movement_confirmed = bool(row.get("movement_confirmed"))

--- a/core/utils.py
+++ b/core/utils.py
@@ -22,7 +22,7 @@ UNMATCHED_MARKET_LOOKUPS = defaultdict(list)
 
 def validate_bet_schema(bet_dict):
     """Validate required keys exist in a bet evaluation result."""
-    required_keys = ["skip", "full_stake", "log"]
+    required_keys = ["skip", "raw_kelly", "log"]
     for key in required_keys:
         if key not in bet_dict:
             raise ValueError(f"Missing required key in bet evaluation: {key}")

--- a/deprecated/update_pending_from_snapshot.py
+++ b/deprecated/update_pending_from_snapshot.py
@@ -52,7 +52,7 @@ def filter_rows(rows: list) -> list:
             logged = bool(row.get("logged"))
             ev = float(row.get("ev_percent", 0) or 0)
             rk = float(row.get("raw_kelly", 0) or 0)
-            stake = float(row.get("stake", row.get("full_stake", 0)) or 0)
+            stake = float(row.get("stake", row.get("raw_kelly", 0)) or 0)
         except Exception:
             continue
 


### PR DESCRIPTION
## Summary
- replace `full_stake` usage with `raw_kelly`
- drop deprecated field when evaluating bets and generating snapshots
- update log messages and Discord embeds to use `raw_kelly`
- adjust confirmation and snapshot utilities
- keep tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a646d930832c9d4033cfdbbd35df