### PR TITLE
Replace full stake references with raw kelly

### DIFF
--- a/core/confirmation_utils.py
+++ b/core/confirmation_utils.py
@@ -224,7 +224,7 @@ def evaluate_late_confirmed_bet(
         print(f"🔁 Using raw_kelly stake without confirmation scaling: {raw_kelly:.4f}")
         target_stake = round(raw_kelly, 4)
         try:
-            max_full = float(bet.get("full_stake", target_stake))
+            max_full = float(bet.get("raw_kelly", target_stake))
         except Exception:
             max_full = target_stake
         target_stake = min(target_stake, max_full)
@@ -232,7 +232,7 @@ def evaluate_late_confirmed_bet(
         updated.update(
             {
                 "stake": target_stake,
-                "full_stake": target_stake,
+                "raw_kelly": target_stake,
                 "entry_type": "first",
                 "consensus_prob": new_prob,
                 "market_prob": new_prob,
@@ -243,7 +243,7 @@ def evaluate_late_confirmed_bet(
     # Top-up: scale to raw Kelly ignoring confirmation
     target_stake = raw_kelly
     try:
-        max_full = float(bet.get("full_stake", target_stake))
+        max_full = float(bet.get("raw_kelly", target_stake))
     except Exception:
         max_full = target_stake
 
@@ -257,7 +257,7 @@ def evaluate_late_confirmed_bet(
     updated.update(
         {
             "stake": delta,
-            "full_stake": target_stake,
+            "raw_kelly": target_stake,
             "entry_type": "top-up",
             "consensus_prob": new_prob,
             "market_prob": new_prob,

--- a/core/should_log_bet.py
+++ b/core/should_log_bet.py
@@ -108,7 +108,7 @@ def build_skipped_evaluation(
     result = {
         "game_id": game_id,
         "log": False,
-        "full_stake": 0.0,
+        "raw_kelly": 0.0,
         "skip_reason": reason,
         "skip": True,
         "reason": reason,
@@ -215,13 +215,13 @@ def should_log_bet(
     market = new_bet["market"]
     side = normalize_label_for_odds(new_bet["side"], market)
     new_bet["side"] = side  # ensure consistent formatting
-    # ``full_stake`` may be absent in legacy entries; fall back to ``stake``
+    # ``raw_kelly`` may be absent in legacy entries; fall back to ``stake``
     # or 0.0 to avoid KeyError.
     stake = round_stake(
         float(
             new_bet.get(
                 "raw_kelly",
-                new_bet.get("full_stake", new_bet.get("stake", 0.0)),
+                new_bet.get("stake", 0.0),
             )
         )
     )
@@ -494,7 +494,7 @@ def should_log_bet(
             "skip",
             "log",
             "entry_type",
-            "full_stake",
+            "raw_kelly",
             "stake",
             "skip_reason",
         ]:
@@ -504,7 +504,7 @@ def should_log_bet(
             "log": True,
             "entry_type": "first",
             "stake": stake,
-            "full_stake": stake,
+            "raw_kelly": stake,
             "ev": ev,
             "game_id": game_id,
             "side": new_bet["side"],
@@ -521,7 +521,7 @@ def should_log_bet(
             "skip",
             "log",
             "entry_type",
-            "full_stake",
+            "raw_kelly",
             "stake",
             "skip_reason",
         ]:
@@ -531,7 +531,7 @@ def should_log_bet(
             "log": True,
             "entry_type": "top-up",
             "stake": rounded_delta,
-            "full_stake": stake,
+            "raw_kelly": stake,
             "partial_stake": rounded_delta,
             "ev": ev,
             "game_id": game_id,

--- a/core/snapshot_core.py
+++ b/core/snapshot_core.py
@@ -509,8 +509,8 @@ def send_bet_snapshot_to_discord(
     try:
         min_stake = 1.0
         stake_vals = None
-        if "full_stake" in df.columns:
-            stake_vals = pd.to_numeric(df["full_stake"], errors="coerce")
+        if "raw_kelly" in df.columns:
+            stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
         elif "stake" in df.columns:
             stake_vals = pd.to_numeric(df["stake"], errors="coerce")
         elif "Stake" in df.columns:
@@ -605,7 +605,7 @@ def send_bet_snapshot_to_discord(
         "blended_fv",
         "market_class",
         "_raw_sportsbook",
-        "full_stake",
+        "raw_kelly",
         "blended_prob",
         "segment",
         "date_simulated",
@@ -1085,7 +1085,6 @@ def build_snapshot_rows(
                 "market_odds": price,
                 "ev_percent": round(ev_pct, 2),
                 "stake": stake,
-                "full_stake": stake,
                 "raw_kelly": raw_kelly,
                 "segment": segment,
                 "market_class": market_class,
@@ -1557,7 +1556,6 @@ def expand_snapshot_rows_with_kelly(
                     "market_odds": odds_val,
                     "ev_percent": round(ev, 2),
                     "stake": stake,
-                    "full_stake": stake,
                     "raw_kelly": raw_kelly,
                     "_raw_sportsbook": per_book,
                     "consensus_books": per_book,
@@ -1770,8 +1768,8 @@ def dispatch_snapshot_rows(
     # Stake filter (prospective bets bypass minimum)
     try:
         stake_vals = None
-        if "full_stake" in df.columns:
-            stake_vals = pd.to_numeric(df["full_stake"], errors="coerce")
+        if "raw_kelly" in df.columns:
+            stake_vals = pd.to_numeric(df["raw_kelly"], errors="coerce")
         elif "stake" in df.columns:
             stake_vals = pd.to_numeric(df["stake"], errors="coerce")
         elif "Stake" in df.columns:

--- a/core/unified_snapshot_generator.py
+++ b/core/unified_snapshot_generator.py
@@ -270,7 +270,7 @@ def _enrich_snapshot_row(row: dict, *, debug_movement: bool = False) -> None:
     # 🧩 Enrich: early/low-EV gating
     ev = row.get("ev_percent", 0.0) or 0.0
     rk = row.get("raw_kelly", 0.0) or 0.0
-    stake = row.get("stake", row.get("full_stake", 0.0)) or 0.0
+    stake = row.get("stake", row.get("raw_kelly", 0.0)) or 0.0
     if ev < 5.0 and rk < 1.0 and stake < 1.0:
         row.setdefault("skip_reason", "low_ev")
 
@@ -346,7 +346,7 @@ def _merge_persistent_fields(rows: list, prior_map: dict) -> None:
             except Exception:
                 ev = 0.0
             try:
-                stake = float(row.get("stake", row.get("full_stake", 0) or 0))
+                stake = float(row.get("stake", row.get("raw_kelly", 0) or 0))
             except Exception:
                 stake = 0.0
 
@@ -761,7 +761,7 @@ def main() -> None:
                 for row in all_rows:
                     try:
                         ev = float(row.get("ev_percent", 0))
-                        stake = float(row.get("stake", row.get("full_stake", 0) or 0))
+                        stake = float(row.get("stake", row.get("raw_kelly", 0) or 0))
                         if ev < 5.0 or stake < 1.0:
                             continue
 
@@ -837,7 +837,7 @@ def main() -> None:
                             continue
 
                         ev = float(row.get("ev_percent", 0))
-                        stake = float(row.get("stake", row.get("full_stake", 0) or 0))
+                        stake = float(row.get("stake", row.get("raw_kelly", 0) or 0))
                         raw_kelly = float(row.get("raw_kelly", 0) or 0)
                         required_move = row.get("required_move")
                         movement_confirmed = bool(row.get("movement_confirmed"))

--- a/core/utils.py
+++ b/core/utils.py
@@ -22,7 +22,7 @@ UNMATCHED_MARKET_LOOKUPS = defaultdict(list)
 
 def validate_bet_schema(bet_dict):
     """Validate required keys exist in a bet evaluation result."""
-    required_keys = ["skip", "full_stake", "log"]
+    required_keys = ["skip", "raw_kelly", "log"]
     for key in required_keys:
         if key not in bet_dict:
             raise ValueError(f"Missing required key in bet evaluation: {key}")

--- a/deprecated/update_pending_from_snapshot.py
+++ b/deprecated/update_pending_from_snapshot.py
@@ -52,7 +52,7 @@ def filter_rows(rows: list) -> list:
             logged = bool(row.get("logged"))
             ev = float(row.get("ev_percent", 0) or 0)
             rk = float(row.get("raw_kelly", 0) or 0)
-            stake = float(row.get("stake", row.get("full_stake", 0)) or 0)
+            stake = float(row.get("stake", row.get("raw_kelly", 0)) or 0)
         except Exception:
             continue
 


### PR DESCRIPTION
## Summary
- depend on `raw_kelly` in bet validation and logging logic
- strip remaining `full_stake` references and update messaging
- keep tests green

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871a646d930832c9d4033cfdbbd35df